### PR TITLE
Add Miyorare source compatibility foundation

### DIFF
--- a/.github/workflows/miyorare-source-pack-check.yml
+++ b/.github/workflows/miyorare-source-pack-check.yml
@@ -1,0 +1,81 @@
+name: Miyorare Source Pack Check
+
+on:
+  pull_request:
+    branches:
+      - beta
+    paths:
+      - 'extensions/miyorare-sources/**'
+      - '.github/workflows/miyorare-source-pack-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: miyorare-source-packs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-pack:
+    name: Build Miyorare-${{ matrix.pack }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pack: [id, en]
+
+    steps:
+      - name: Checkout Miyorare
+        uses: actions/checkout@v5
+
+      - name: Checkout pinned UMA source
+        uses: actions/checkout@v5
+        with:
+          repository: InvalidDavid/UMA
+          ref: a0ebc9ffc7de02b7b50cbcb620092d0a9263c785
+          path: _upstream/uma
+          fetch-depth: 1
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: '8.14.3'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+
+      - name: Prepare curated source pack
+        run: |
+          python3 extensions/miyorare-sources/tools/prepare_pack.py \
+            --manifest extensions/miyorare-sources/packs.json \
+            --upstream _upstream/uma \
+            --pack '${{ matrix.pack }}'
+
+      - name: Build dexed Tsuki plugin
+        working-directory: _upstream/uma
+        run: |
+          chmod +x gradlew
+          ./gradlew buildJar --rerun-tasks --no-daemon
+
+      - name: Verify and finalize artifact
+        run: |
+          python3 extensions/miyorare-sources/tools/finalize_pack.py \
+            --manifest extensions/miyorare-sources/packs.json \
+            --upstream _upstream/uma \
+            --pack '${{ matrix.pack }}' \
+            --output build/miyorare-source-packs/${{ matrix.pack }}
+
+      - name: Upload staging pack
+        uses: actions/upload-artifact@v4
+        with:
+          name: miyorare-${{ matrix.pack }}-staging
+          path: build/miyorare-source-packs/${{ matrix.pack }}/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/source-compatibility-check.yml
+++ b/.github/workflows/source-compatibility-check.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/**'
       - 'app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/migration/**'
+      - 'app/src/main/kotlin/org/koitharu/kotatsu/tsuki/**'
       - 'app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/**'
       - 'app/src/test/kotlin/org/koitharu/kotatsu/settings/sources/migration/**'
       - 'docs/source-compatibility.md'
@@ -46,6 +47,7 @@ jobs:
           ./gradlew :app:testDebugUnitTest --no-daemon --stacktrace \
             --tests org.koitharu.kotatsu.sources.compat.StoredSourceIdentityTest \
             --tests org.koitharu.kotatsu.sources.compat.DownloadedContentMatcherTest \
+            --tests org.koitharu.kotatsu.sources.compat.DownloadReconnectPlannerTest \
             --tests org.koitharu.kotatsu.settings.sources.migration.LibrarySourceOptionTest
 
       - name: Compile debug Kotlin

--- a/.github/workflows/source-compatibility-check.yml
+++ b/.github/workflows/source-compatibility-check.yml
@@ -8,6 +8,7 @@ on:
       - 'app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/**'
       - 'app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/migration/**'
       - 'app/src/main/kotlin/org/koitharu/kotatsu/tsuki/**'
+      - 'app/src/main/kotlin/org/koitharu/kotatsu/local/data/LocalMangaRepository.kt'
       - 'app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/**'
       - 'app/src/test/kotlin/org/koitharu/kotatsu/settings/sources/migration/**'
       - 'docs/source-compatibility.md'

--- a/.github/workflows/source-compatibility-check.yml
+++ b/.github/workflows/source-compatibility-check.yml
@@ -1,0 +1,52 @@
+name: Source Compatibility Check
+
+on:
+  pull_request:
+    branches:
+      - beta
+    paths:
+      - 'app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/**'
+      - 'app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/migration/**'
+      - 'app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/**'
+      - 'app/src/test/kotlin/org/koitharu/kotatsu/settings/sources/migration/**'
+      - 'docs/source-compatibility.md'
+      - '.github/workflows/source-compatibility-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: source-compat-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify source compatibility foundation
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run targeted source compatibility tests
+        run: |
+          ./gradlew :app:testDebugUnitTest --no-daemon --stacktrace \
+            --tests org.koitharu.kotatsu.sources.compat.StoredSourceIdentityTest \
+            --tests org.koitharu.kotatsu.sources.compat.DownloadedContentMatcherTest \
+            --tests org.koitharu.kotatsu.settings.sources.migration.LibrarySourceOptionTest
+
+      - name: Compile debug Kotlin
+        run: ./gradlew :app:compileDebugKotlin --no-daemon --stacktrace

--- a/.github/workflows/source-compatibility-check.yml
+++ b/.github/workflows/source-compatibility-check.yml
@@ -9,8 +9,10 @@ on:
       - 'app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/migration/**'
       - 'app/src/main/kotlin/org/koitharu/kotatsu/tsuki/**'
       - 'app/src/main/kotlin/org/koitharu/kotatsu/local/data/LocalMangaRepository.kt'
+      - 'app/src/main/kotlin/org/koitharu/kotatsu/local/data/index/**'
       - 'app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/**'
       - 'app/src/test/kotlin/org/koitharu/kotatsu/settings/sources/migration/**'
+      - 'app/src/test/kotlin/org/koitharu/kotatsu/local/data/index/**'
       - 'docs/source-compatibility.md'
       - '.github/workflows/source-compatibility-check.yml'
   workflow_dispatch:
@@ -49,6 +51,7 @@ jobs:
             --tests org.koitharu.kotatsu.sources.compat.StoredSourceIdentityTest \
             --tests org.koitharu.kotatsu.sources.compat.DownloadedContentMatcherTest \
             --tests org.koitharu.kotatsu.sources.compat.DownloadReconnectPlannerTest \
+            --tests org.koitharu.kotatsu.local.data.index.DownloadPathAliasTest \
             --tests org.koitharu.kotatsu.settings.sources.migration.LibrarySourceOptionTest
 
       - name: Compile debug Kotlin

--- a/app/src/main/kotlin/org/koitharu/kotatsu/local/data/LocalMangaRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/local/data/LocalMangaRepository.kt
@@ -246,7 +246,12 @@ class LocalMangaRepository @Inject constructor(
 						return@launch
 					}
 					if (evidence != DownloadedContentMatch.NONE) {
-						reconnectCandidates += ReconnectScanCandidate(mangaInput, evidence)
+						reconnectCandidates += ReconnectScanCandidate(
+							parser = mangaInput,
+							evidence = evidence,
+							localMangaId = mangaInfo.id,
+							file = file,
+						)
 					}
 				}
 			}
@@ -260,7 +265,13 @@ class LocalMangaRepository @Inject constructor(
 		val candidates = synchronized(reconnectCandidates) { reconnectCandidates.toList() }
 		val selection = DownloadReconnectPlanner.select(candidates.map { it.evidence })
 		if (selection is DownloadReconnectSelection.Automatic) {
-			send(candidates[selection.index].parser)
+			val candidate = candidates[selection.index]
+			localMangaIndex.registerDownloadAlias(
+				remoteMangaId = remoteManga.id,
+				localMangaId = candidate.localMangaId,
+				file = candidate.file,
+			)
+			send(candidate.parser)
 		}
 	}.firstOrNull()
 
@@ -386,7 +397,13 @@ class LocalMangaRepository @Inject constructor(
 	private fun linkDownloadedChapters(remoteManga: Manga, localManga: LocalManga): LocalManga {
 		val remoteChapters = remoteManga.chapters.orEmpty()
 		val localChapters = localManga.manga.chapters.orEmpty()
-		if (remoteChapters.isEmpty() || localChapters.isEmpty()) return localManga
+		if (remoteChapters.isEmpty() || localChapters.isEmpty()) {
+			return if (localManga.manga.id == remoteManga.id) {
+				localManga
+			} else {
+				localManga.copy(manga = localManga.manga.copy(id = remoteManga.id))
+			}
+		}
 		val remainingLocal = localChapters.toMutableList()
 		val linked = ArrayList<MangaChapter>(localChapters.size)
 		val branchIndexes = HashMap<String?, Int>()
@@ -415,7 +432,12 @@ class LocalMangaRepository @Inject constructor(
 			linked += remoteChapter.copy(url = localChapter.url, source = LocalMangaSource)
 		}
 		linked.addAll(remainingLocal)
-		return localManga.copy(manga = localManga.manga.copy(chapters = linked))
+		return localManga.copy(
+			manga = localManga.manga.copy(
+				id = remoteManga.id,
+				chapters = linked,
+			),
+		)
 	}
 
 	private fun expectedChapterBaseName(chapter: MangaChapter, branchIndex: Int, isNovel: Boolean): String {
@@ -532,6 +554,8 @@ class LocalMangaRepository @Inject constructor(
 	private data class ReconnectScanCandidate(
 		val parser: LocalMangaParser,
 		val evidence: DownloadedContentMatch,
+		val localMangaId: Long,
+		val file: File,
 	)
 
 	private data class LocalFilterKey(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/local/data/LocalMangaRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/local/data/LocalMangaRepository.kt
@@ -43,7 +43,11 @@ import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.util.levenshteinDistance
 import org.koitharu.kotatsu.parsers.util.mapToSet
 import org.koitharu.kotatsu.parsers.util.runCatchingCancellable
+import org.koitharu.kotatsu.sources.compat.DownloadReconnectPlanner
+import org.koitharu.kotatsu.sources.compat.DownloadReconnectSelection
+import org.koitharu.kotatsu.sources.compat.DownloadedContentMatch
 import java.io.File
+import java.util.Collections
 import java.util.EnumSet
 import java.util.Locale
 import javax.inject.Inject
@@ -62,6 +66,7 @@ class LocalMangaRepository @Inject constructor(
 	private val storageManager: LocalStorageManager,
 	private val localMangaIndex: LocalMangaIndex,
 	@LocalStorageChanges private val localStorageChanges: MutableSharedFlow<LocalManga?>,
+	private val downloadReconnectPlanner: DownloadReconnectPlanner,
 	private val settings: AppSettings,
 	private val lock: MangaLock,
 ) : MangaRepository {
@@ -224,17 +229,24 @@ class LocalMangaRepository @Inject constructor(
 
 	private suspend fun findSavedMangaByScanning(remoteManga: Manga): LocalMangaParser? = channelFlow {
 		val queue = Channel<File>(FILE_SCAN_QUEUE_CAPACITY)
+		val reconnectCandidates = Collections.synchronizedList(ArrayList<ReconnectScanCandidate>())
 		val dispatcher = Dispatchers.IO.limitedParallelism(MAX_PARALLELISM)
-		repeat(MAX_PARALLELISM) {
+		val workers = List(MAX_PARALLELISM) {
 			launch(dispatcher) {
 				for (file in queue) {
 					val mangaInput = LocalMangaParser.getOrNull(file) ?: continue
-					val matches = runCatchingCancellable {
-						mangaInput.getMangaInfo()?.id == remoteManga.id
-					}.onFailure { it.printStackTraceDebug() }.getOrDefault(false)
-					if (matches) {
+					val mangaInfo = runCatchingCancellable {
+						mangaInput.getMangaInfo()
+					}.onFailure { it.printStackTraceDebug() }.getOrNull() ?: continue
+					val evidence = runCatchingCancellable {
+						downloadReconnectPlanner.evidence(remoteManga, mangaInfo)
+					}.onFailure { it.printStackTraceDebug() }.getOrDefault(DownloadedContentMatch.NONE)
+					if (evidence == DownloadedContentMatch.EXACT_ID) {
 						send(mangaInput)
 						return@launch
+					}
+					if (evidence != DownloadedContentMatch.NONE) {
+						reconnectCandidates += ReconnectScanCandidate(mangaInput, evidence)
 					}
 				}
 			}
@@ -243,6 +255,12 @@ class LocalMangaRepository @Inject constructor(
 			for (file in getAllFiles()) queue.send(file)
 		} finally {
 			queue.close()
+		}
+		workers.forEach { it.join() }
+		val candidates = synchronized(reconnectCandidates) { reconnectCandidates.toList() }
+		val selection = DownloadReconnectPlanner.select(candidates.map { it.evidence })
+		if (selection is DownloadReconnectSelection.Automatic) {
+			send(candidates[selection.index].parser)
 		}
 	}.firstOrNull()
 
@@ -510,6 +528,11 @@ class LocalMangaRepository @Inject constructor(
 	)
 
 	private fun File.shouldSkip(): Boolean = isDirectory && File(this, FILENAME_SKIP).exists()
+
+	private data class ReconnectScanCandidate(
+		val parser: LocalMangaParser,
+		val evidence: DownloadedContentMatch,
+	)
 
 	private data class LocalFilterKey(
 		val query: String?,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/local/data/index/DownloadPathAlias.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/local/data/index/DownloadPathAlias.kt
@@ -1,0 +1,23 @@
+package org.koitharu.kotatsu.local.data.index
+
+/**
+ * Persistent, non-destructive link from a provider-specific remote manga id to an existing local
+ * download. The original local manga id is retained so a reused/replaced path can be rejected.
+ */
+internal data class DownloadPathAlias(
+	val localMangaId: Long,
+	val path: String,
+) {
+	fun serialize(): String = "$localMangaId|$path"
+
+	companion object {
+		fun parse(raw: String?): DownloadPathAlias? {
+			if (raw.isNullOrEmpty()) return null
+			val separator = raw.indexOf('|')
+			if (separator <= 0 || separator == raw.lastIndex) return null
+			val localMangaId = raw.substring(0, separator).toLongOrNull() ?: return null
+			val path = raw.substring(separator + 1).takeIf { it.isNotBlank() } ?: return null
+			return DownloadPathAlias(localMangaId, path)
+		}
+	}
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/local/data/index/LocalMangaIndex.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/local/data/index/LocalMangaIndex.kt
@@ -133,21 +133,34 @@ class LocalMangaIndex @Inject constructor(
 		if (path == null && mutex.isLocked) { // wait for updating complete
 			path = mutex.withLock { dao.findPath(mangaId) }
 		}
+		val alias = if (path == null) readDownloadAlias(mangaId) else null
+		if (path == null) {
+			path = alias?.path
+		}
 		if (path == null) {
 			return null
 		}
 		val file = File(path)
-		val result = runCatchingCancellable {
+		val parsed = runCatchingCancellable {
 			LocalMangaParser(file).getManga(withDetails)
 		}.onFailure {
 			it.printStackTraceDebug()
 		}.getOrNull()
+		val result = when {
+			parsed == null -> null
+			alias == null -> parsed
+			parsed.manga.id != alias.localMangaId -> null
+			else -> parsed.copy(manga = parsed.manga.copy(id = mangaId))
+		}
 		if (result == null && file.isOnReadableRoot()) {
-			// A parse failure on storage that is currently reachable means this persisted row can no
-			// longer produce a Local manga. Remove only the exact path we attempted: an index rebuild or
-			// download may have replaced it while parsing. Unavailable SD roots are deliberately kept.
+			// A parse failure on reachable storage means the exact row/alias is stale. Unavailable SD
+			// roots are deliberately retained so temporarily ejected storage is never forgotten.
 			mutex.withLock {
-				if (dao.findPath(mangaId) == path) {
+				if (alias != null) {
+					if (readDownloadAlias(mangaId)?.path == path) {
+						removeDownloadAlias(mangaId)
+					}
+				} else if (dao.findPath(mangaId) == path) {
 					dao.delete(mangaId)
 					cachedList = null
 				}
@@ -177,10 +190,29 @@ class LocalMangaIndex @Inject constructor(
 	}
 
 	suspend operator fun contains(mangaId: Long): Boolean {
-		return db.getLocalMangaIndexDao().findPath(mangaId) != null
+		return db.getLocalMangaIndexDao().findPath(mangaId) != null || readDownloadAlias(mangaId) != null
+	}
+
+	/**
+	 * Persist a provider-specific remote id as an alias to an existing download without changing the
+	 * download's metadata, moving files, or adding a duplicate item to the Local index.
+	 */
+	suspend fun registerDownloadAlias(remoteMangaId: Long, localMangaId: Long, file: File) {
+		if (remoteMangaId == localMangaId) return
+		val alias = DownloadPathAlias(localMangaId = localMangaId, path = file.path)
+		mutex.withLock {
+			prefs.edit { putString(aliasKey(remoteMangaId), alias.serialize()) }
+		}
 	}
 
 	suspend fun put(manga: LocalManga) = mutex.withLock {
+		val alias = readDownloadAlias(manga.manga.id)
+		if (alias?.path == manga.file.path) {
+			return@withLock
+		}
+		if (alias != null) {
+			removeDownloadAlias(manga.manga.id)
+		}
 		if (db.getLocalMangaIndexDao().findPath(manga.manga.id) == manga.file.path) {
 			return@withLock
 		}
@@ -192,6 +224,16 @@ class LocalMangaIndex @Inject constructor(
 
 	suspend fun delete(mangaId: Long) = mutex.withLock {
 		db.getLocalMangaIndexDao().delete(mangaId)
+		val aliasKeys = prefs.all.asSequence()
+			.filter { (key, value) ->
+				key.startsWith(KEY_ALIAS_PREFIX) &&
+					(key == aliasKey(mangaId) || DownloadPathAlias.parse(value as? String)?.localMangaId == mangaId)
+			}
+			.map { it.key }
+			.toList()
+		if (aliasKeys.isNotEmpty()) {
+			prefs.edit { aliasKeys.forEach(::remove) }
+		}
 		cachedList = null
 	}
 
@@ -217,6 +259,18 @@ class LocalMangaIndex @Inject constructor(
 				changed = true
 			}
 		}
+		val staleAliasKeys = prefs.all.asSequence()
+			.filter { (key, value) ->
+				if (!key.startsWith(KEY_ALIAS_PREFIX)) return@filter false
+				val alias = DownloadPathAlias.parse(value as? String) ?: return@filter true
+				val file = File(alias.path)
+				readableRoots.any { root -> file.isInside(root) } && !file.exists()
+			}
+			.map { it.key }
+			.toList()
+		if (staleAliasKeys.isNotEmpty()) {
+			prefs.edit { staleAliasKeys.forEach(::remove) }
+		}
 		if (changed) {
 			cachedList = null
 			_rebuildEvents.tryEmit(Unit)
@@ -236,6 +290,15 @@ class LocalMangaIndex @Inject constructor(
 		mangaId = manga.id,
 		path = file.path,
 	)
+
+	private fun readDownloadAlias(mangaId: Long): DownloadPathAlias? =
+		DownloadPathAlias.parse(prefs.getString(aliasKey(mangaId), null))
+
+	private fun removeDownloadAlias(mangaId: Long) {
+		prefs.edit { remove(aliasKey(mangaId)) }
+	}
+
+	private fun aliasKey(mangaId: Long): String = "$KEY_ALIAS_PREFIX$mangaId"
 
 	private fun File.isConfiguredRootContainer(configuredRoots: Set<File>): Boolean {
 		if (!isDirectory) return false
@@ -257,6 +320,7 @@ class LocalMangaIndex @Inject constructor(
 
 		private const val PREF_NAME = "_local_index"
 		private const val KEY_VERSION = "ver"
+		private const val KEY_ALIAS_PREFIX = "download_alias_"
 		// Scanner semantics changed to recognize standalone PDF files as local manga.
 		// Bump the persisted index version so existing installs rebuild once and pick them up.
 		private const val VERSION = 3

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/migration/BrokenSourcesMigrationViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/migration/BrokenSourcesMigrationViewModel.kt
@@ -1,9 +1,9 @@
 package org.koitharu.kotatsu.settings.sources.migration
 
 import android.content.Context
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.compose.runtime.Immutable
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -22,6 +22,7 @@ import org.koitharu.kotatsu.mihon.MihonExtensionManager
 import org.koitharu.kotatsu.mihon.model.MihonMangaSource
 import org.koitharu.kotatsu.settings.sources.catalog.ExternalExtensionRepoRepository
 import org.koitharu.kotatsu.settings.sources.catalog.ExtensionStoreManager
+import org.koitharu.kotatsu.sources.compat.SourceAliasRegistry
 import javax.inject.Inject
 
 @HiltViewModel
@@ -31,6 +32,7 @@ class BrokenSourcesMigrationViewModel @Inject constructor(
 	private val extensionRepoRepository: ExternalExtensionRepoRepository,
 	private val extensionStoreManager: ExtensionStoreManager,
 	private val kotatsuSourceMap: KotatsuSourceMap,
+	private val sourceAliasRegistry: SourceAliasRegistry,
 	@ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -84,6 +86,7 @@ class BrokenSourcesMigrationViewModel @Inject constructor(
 		metadata: SourceMetadata,
 	): List<LibrarySourceOption> {
 		val unmerged = usages.map { usage ->
+			val canonicalIdentity = sourceAliasRegistry.resolve(usage.source)
 			val source = MangaSource(usage.source, usage.sourceTitle)
 			val mihonId = usage.source
 				.takeIf { it.startsWith(MIHON_PREFIX) }
@@ -128,6 +131,7 @@ class BrokenSourcesMigrationViewModel @Inject constructor(
 					?.takeUnless { it in metadata.installedIds }
 					?.let(metadata.repositoryIcons::get),
 				sourceId = representedSourceId,
+				canonicalKey = canonicalIdentity.canonicalId.value,
 			)
 		}
 		return mergeLibrarySourceOptions(unmerged)
@@ -173,25 +177,24 @@ internal fun mergeLibrarySourceOptions(
 	options: List<LibrarySourceOption>,
 ): List<LibrarySourceOption> {
 	return options
-			.groupBy { option ->
-				option.sourceId?.let { "mihon:$it" } ?: "legacy:${option.title.trim().lowercase()}"
-			}
-			.map { (canonicalKey, group) ->
-				val iconSource = group.firstOrNull { !it.isUnavailable && it.iconUrl != null }
-					?: group.firstOrNull { !it.isUnavailable }
-					?: group.first()
-				LibrarySourceOption(
-					key = canonicalKey,
-					sourceKeys = group.flatMapTo(linkedSetOf()) { it.sourceKeys },
-					title = group.first().title,
-					mangaCount = group.sumOf { it.mangaCount },
-					isUnavailable = group.all { it.isUnavailable },
-					iconSourceKey = iconSource.iconSourceKey,
-					iconUrl = iconSource.iconUrl,
-					sourceId = group.firstNotNullOfOrNull { it.sourceId },
-				)
-			}
-			.sortedBy { it.title.lowercase() }
+		.groupBy { it.canonicalKey }
+		.map { (canonicalKey, group) ->
+			val iconSource = group.firstOrNull { !it.isUnavailable && it.iconUrl != null }
+				?: group.firstOrNull { !it.isUnavailable }
+				?: group.first()
+			LibrarySourceOption(
+				key = canonicalKey,
+				sourceKeys = group.flatMapTo(linkedSetOf()) { it.sourceKeys },
+				title = group.first().title,
+				mangaCount = group.sumOf { it.mangaCount },
+				isUnavailable = group.all { it.isUnavailable },
+				iconSourceKey = iconSource.iconSourceKey,
+				iconUrl = iconSource.iconUrl,
+				sourceId = group.firstNotNullOfOrNull { it.sourceId },
+				canonicalKey = canonicalKey,
+			)
+		}
+		.sortedBy { it.title.lowercase() }
 }
 
 private fun String.toReadableSourceName(): String {
@@ -220,6 +223,8 @@ data class LibrarySourceOption(
 	val iconUrl: String?,
 	/** Exact Mihon target represented by this row; null only for unmapped legacy sources. */
 	val sourceId: Long? = null,
+	/** Provider-neutral grouping key. Display titles are deliberately not used as identity. */
+	val canonicalKey: String = sourceId?.let { "catalogue:$it" } ?: "stored:$key",
 )
 
 private data class SourceMetadata(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/CanonicalSourceIdentity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/CanonicalSourceIdentity.kt
@@ -1,0 +1,134 @@
+package org.koitharu.kotatsu.sources.compat
+
+import java.util.Locale
+
+/**
+ * Provider-neutral identity used to decide whether two stored source names represent the same
+ * catalogue. The value is deliberately independent from display names: two unrelated sources may
+ * share a title, and changing a translated/display title must never move user data.
+ */
+@JvmInline
+value class CanonicalSourceId(val value: String) {
+	init {
+		require(value.isNotBlank()) { "Canonical source id must not be blank" }
+	}
+
+	override fun toString(): String = value
+
+	companion object {
+		fun catalogue(sourceId: Long): CanonicalSourceId = CanonicalSourceId("catalogue:$sourceId")
+	}
+}
+
+enum class SourceBackend {
+	/** Reserved for official Miyorare source packs. */
+	MIYORARE,
+	/** Mihon/Keiyoushi-compatible extension APK. */
+	MIHON,
+	/** Tsuki/Usagi plugin JAR, including UMA/Gekkoushi. */
+	TSUKI,
+	/** LNReader-compatible JavaScript plugin. */
+	LNREADER,
+	/** Built-in/legacy Kotatsu parser source. */
+	KOTATSU,
+	/** LOCAL/UNKNOWN and other app-internal identities. */
+	INTERNAL,
+}
+
+data class CanonicalSourceIdentity(
+	val canonicalId: CanonicalSourceId,
+	val backend: SourceBackend,
+	/** Exact value persisted by Miyorare. Never rewrite this merely to canonicalize it. */
+	val storedName: String,
+	/** Mihon CatalogueSource.id when this identity has a known Mihon-compatible target. */
+	val catalogueSourceId: Long? = null,
+	val mappedSourceName: String? = null,
+	val mappedPackageName: String? = null,
+	/** True only when an explicit compatibility map, rather than the stored provider key, resolved it. */
+	val isAlias: Boolean = false,
+)
+
+/**
+ * Pure parser for stored source identities. It performs no filesystem, database, plugin loading or
+ * network work and is therefore safe on hot library/download paths.
+ */
+object StoredSourceIdentity {
+	const val MIYORARE_PREFIX = "MIYORARE:"
+	const val MIHON_PREFIX = "MIHON_"
+	const val TSUKI_PREFIX = "TSUKI:"
+	const val LNREADER_PREFIX = "LN_"
+
+	fun direct(storedName: String): CanonicalSourceIdentity {
+		val name = storedName.trim()
+		require(name.isNotEmpty()) { "Stored source name must not be blank" }
+
+		if (name == "LOCAL" || name == "UNKNOWN") {
+			return CanonicalSourceIdentity(
+				canonicalId = CanonicalSourceId("internal:${name.lowercase(Locale.ROOT)}"),
+				backend = SourceBackend.INTERNAL,
+				storedName = name,
+			)
+		}
+
+		if (name.startsWith(MIYORARE_PREFIX)) {
+			return CanonicalSourceIdentity(
+				canonicalId = CanonicalSourceId("miyorare:${name.removePrefix(MIYORARE_PREFIX)}"),
+				backend = SourceBackend.MIYORARE,
+				storedName = name,
+			)
+		}
+
+		if (name.startsWith(MIHON_PREFIX)) {
+			val raw = name.removePrefix(MIHON_PREFIX)
+			val sourceId = raw.substringBefore(':').toLongOrNull()
+			return CanonicalSourceIdentity(
+				canonicalId = if (sourceId != null) {
+					CanonicalSourceId.catalogue(sourceId)
+				} else {
+					CanonicalSourceId("provider:mihon:$raw")
+				},
+				backend = SourceBackend.MIHON,
+				storedName = name,
+				catalogueSourceId = sourceId,
+			)
+		}
+
+		if (name.startsWith(TSUKI_PREFIX)) {
+			return CanonicalSourceIdentity(
+				// Keep the encoded provider/plugin/source tuple byte-for-byte. Source names may be case-sensitive.
+				canonicalId = CanonicalSourceId("provider:tsuki:${name.removePrefix(TSUKI_PREFIX)}"),
+				backend = SourceBackend.TSUKI,
+				storedName = name,
+			)
+		}
+
+		if (name.startsWith(LNREADER_PREFIX)) {
+			return CanonicalSourceIdentity(
+				canonicalId = CanonicalSourceId("provider:lnreader:${name.removePrefix(LNREADER_PREFIX)}"),
+				backend = SourceBackend.LNREADER,
+				storedName = name,
+			)
+		}
+
+		return CanonicalSourceIdentity(
+			canonicalId = CanonicalSourceId("kotatsu:${name.uppercase(Locale.ROOT)}"),
+			backend = SourceBackend.KOTATSU,
+			storedName = name,
+		)
+	}
+
+	fun mappedLegacy(
+		storedName: String,
+		catalogueSourceId: Long,
+		sourceName: String? = null,
+		packageName: String? = null,
+	): CanonicalSourceIdentity = CanonicalSourceIdentity(
+		canonicalId = CanonicalSourceId.catalogue(catalogueSourceId),
+		backend = SourceBackend.KOTATSU,
+		storedName = storedName.trim(),
+		catalogueSourceId = catalogueSourceId,
+		mappedSourceName = sourceName,
+		mappedPackageName = packageName,
+		isAlias = true,
+	)
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/CanonicalSourceIdentity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/CanonicalSourceIdentity.kt
@@ -31,7 +31,7 @@ enum class SourceBackend {
 	LNREADER,
 	/** Built-in/legacy Kotatsu parser source. */
 	KOTATSU,
-	/** LOCAL/UNKNOWN and other app-internal identities. */
+	/** LOCAL/UNKNOWN, invalid legacy rows and other app-internal identities. */
 	INTERNAL,
 }
 
@@ -60,7 +60,15 @@ object StoredSourceIdentity {
 
 	fun direct(storedName: String): CanonicalSourceIdentity {
 		val name = storedName.trim()
-		require(name.isNotEmpty()) { "Stored source name must not be blank" }
+		if (name.isEmpty()) {
+			// Corrupt/very old backup rows must not crash the migration screen. Preserve the raw row and
+			// isolate it instead of guessing a provider.
+			return CanonicalSourceIdentity(
+				canonicalId = CanonicalSourceId("internal:missing-source"),
+				backend = SourceBackend.INTERNAL,
+				storedName = storedName,
+			)
+		}
 
 		if (name == "LOCAL" || name == "UNKNOWN") {
 			return CanonicalSourceIdentity(
@@ -71,9 +79,10 @@ object StoredSourceIdentity {
 		}
 
 		if (name.startsWith(MIYORARE_PREFIX)) {
+			val value = name.removePrefix(MIYORARE_PREFIX).takeIf(String::isNotBlank)
 			return CanonicalSourceIdentity(
-				canonicalId = CanonicalSourceId("miyorare:${name.removePrefix(MIYORARE_PREFIX)}"),
-				backend = SourceBackend.MIYORARE,
+				canonicalId = CanonicalSourceId(value?.let { "miyorare:$it" } ?: "internal:invalid-miyorare-source"),
+				backend = if (value == null) SourceBackend.INTERNAL else SourceBackend.MIYORARE,
 				storedName = name,
 			)
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/CanonicalSourceIdentity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/CanonicalSourceIdentity.kt
@@ -57,6 +57,7 @@ object StoredSourceIdentity {
 	const val MIHON_PREFIX = "MIHON_"
 	const val TSUKI_PREFIX = "TSUKI:"
 	const val LNREADER_PREFIX = "LN_"
+	private const val MIYORARE_TSUKI_PREFIX = "MIYORARE:"
 
 	fun direct(storedName: String): CanonicalSourceIdentity {
 		val name = storedName.trim()
@@ -103,10 +104,16 @@ object StoredSourceIdentity {
 		}
 
 		if (name.startsWith(TSUKI_PREFIX)) {
+			val raw = name.removePrefix(TSUKI_PREFIX)
+			val isOfficialMiyorare = raw.startsWith(MIYORARE_TSUKI_PREFIX)
 			return CanonicalSourceIdentity(
 				// Keep the encoded provider/plugin/source tuple byte-for-byte. Source names may be case-sensitive.
-				canonicalId = CanonicalSourceId("provider:tsuki:${name.removePrefix(TSUKI_PREFIX)}"),
-				backend = SourceBackend.TSUKI,
+				canonicalId = if (isOfficialMiyorare) {
+					CanonicalSourceId("miyorare:${raw.removePrefix(MIYORARE_TSUKI_PREFIX)}")
+				} else {
+					CanonicalSourceId("provider:tsuki:$raw")
+				},
+				backend = if (isOfficialMiyorare) SourceBackend.MIYORARE else SourceBackend.TSUKI,
 				storedName = name,
 			)
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlanner.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlanner.kt
@@ -20,6 +20,20 @@ sealed interface DownloadReconnectPlan {
 	) : DownloadReconnectPlan
 }
 
+internal sealed interface DownloadReconnectSelection {
+	data object NoSafeMatch : DownloadReconnectSelection
+
+	data class Automatic(
+		val index: Int,
+		val evidence: DownloadedContentMatch,
+	) : DownloadReconnectSelection
+
+	data class Ambiguous(
+		val evidence: DownloadedContentMatch,
+		val indexes: List<Int>,
+	) : DownloadReconnectSelection
+}
+
 /**
  * Chooses an existing downloaded copy only when identity evidence is unique and deterministic.
  * Title similarity is deliberately excluded from automatic decisions.
@@ -30,24 +44,21 @@ class DownloadReconnectPlanner @Inject constructor(
 ) {
 
 	suspend fun plan(remote: Manga, downloadedCandidates: Iterable<Manga>): DownloadReconnectPlan {
-		var strongest = DownloadedContentMatch.NONE
-		val strongestCandidates = ArrayList<Manga>()
-		for (candidate in downloadedCandidates) {
-			val evidence = matcher.match(remote, candidate)
-			val comparison = rank(evidence).compareTo(rank(strongest))
-			when {
-				comparison > 0 -> {
-					strongest = evidence
-					strongestCandidates.clear()
-					if (evidence != DownloadedContentMatch.NONE) strongestCandidates += candidate
-				}
-				comparison == 0 && evidence != DownloadedContentMatch.NONE -> strongestCandidates += candidate
-			}
+		val candidates = downloadedCandidates.toList()
+		val matches = ArrayList<DownloadedContentMatch>(candidates.size)
+		for (candidate in candidates) {
+			matches += matcher.match(remote, candidate)
 		}
-		return when {
-			strongestCandidates.isEmpty() -> DownloadReconnectPlan.NoSafeMatch
-			strongestCandidates.size == 1 -> DownloadReconnectPlan.Automatic(strongestCandidates.single(), strongest)
-			else -> DownloadReconnectPlan.Ambiguous(strongest, strongestCandidates)
+		return when (val selection = select(matches)) {
+			DownloadReconnectSelection.NoSafeMatch -> DownloadReconnectPlan.NoSafeMatch
+			is DownloadReconnectSelection.Automatic -> DownloadReconnectPlan.Automatic(
+				manga = candidates[selection.index],
+				evidence = selection.evidence,
+			)
+			is DownloadReconnectSelection.Ambiguous -> DownloadReconnectPlan.Ambiguous(
+				evidence = selection.evidence,
+				candidates = selection.indexes.map(candidates::get),
+			)
 		}
 	}
 
@@ -59,6 +70,27 @@ class DownloadReconnectPlanner @Inject constructor(
 		val title = normalizeTitle(remote.title)
 		if (title.isEmpty()) return emptyList()
 		return downloadedCandidates.filter { normalizeTitle(it.title) == title }
+	}
+
+	internal fun select(matches: List<DownloadedContentMatch>): DownloadReconnectSelection {
+		var strongest = DownloadedContentMatch.NONE
+		val indexes = ArrayList<Int>()
+		for ((index, evidence) in matches.withIndex()) {
+			val comparison = rank(evidence).compareTo(rank(strongest))
+			when {
+				comparison > 0 -> {
+					strongest = evidence
+					indexes.clear()
+					if (evidence != DownloadedContentMatch.NONE) indexes += index
+				}
+				comparison == 0 && evidence != DownloadedContentMatch.NONE -> indexes += index
+			}
+		}
+		return when {
+			indexes.isEmpty() -> DownloadReconnectSelection.NoSafeMatch
+			indexes.size == 1 -> DownloadReconnectSelection.Automatic(indexes.single(), strongest)
+			else -> DownloadReconnectSelection.Ambiguous(strongest, indexes)
+		}
 	}
 
 	private fun rank(match: DownloadedContentMatch): Int = when (match) {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlanner.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlanner.kt
@@ -72,36 +72,38 @@ class DownloadReconnectPlanner @Inject constructor(
 		return downloadedCandidates.filter { normalizeTitle(it.title) == title }
 	}
 
-	internal fun select(matches: List<DownloadedContentMatch>): DownloadReconnectSelection {
-		var strongest = DownloadedContentMatch.NONE
-		val indexes = ArrayList<Int>()
-		for ((index, evidence) in matches.withIndex()) {
-			val comparison = rank(evidence).compareTo(rank(strongest))
-			when {
-				comparison > 0 -> {
-					strongest = evidence
-					indexes.clear()
-					if (evidence != DownloadedContentMatch.NONE) indexes += index
-				}
-				comparison == 0 && evidence != DownloadedContentMatch.NONE -> indexes += index
-			}
-		}
-		return when {
-			indexes.isEmpty() -> DownloadReconnectSelection.NoSafeMatch
-			indexes.size == 1 -> DownloadReconnectSelection.Automatic(indexes.single(), strongest)
-			else -> DownloadReconnectSelection.Ambiguous(strongest, indexes)
-		}
-	}
-
-	private fun rank(match: DownloadedContentMatch): Int = when (match) {
-		DownloadedContentMatch.NONE -> 0
-		DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL -> 1
-		DownloadedContentMatch.PUBLIC_URL -> 2
-		DownloadedContentMatch.EXACT_ID -> 3
-	}
-
 	private fun normalizeTitle(value: String): String = value
 		.trim()
 		.lowercase(Locale.ROOT)
 		.replace(Regex("\\s+"), " ")
+
+	companion object {
+		internal fun select(matches: List<DownloadedContentMatch>): DownloadReconnectSelection {
+			var strongest = DownloadedContentMatch.NONE
+			val indexes = ArrayList<Int>()
+			for ((index, evidence) in matches.withIndex()) {
+				val comparison = rank(evidence).compareTo(rank(strongest))
+				when {
+					comparison > 0 -> {
+						strongest = evidence
+						indexes.clear()
+						if (evidence != DownloadedContentMatch.NONE) indexes += index
+					}
+					comparison == 0 && evidence != DownloadedContentMatch.NONE -> indexes += index
+				}
+			}
+			return when {
+				indexes.isEmpty() -> DownloadReconnectSelection.NoSafeMatch
+				indexes.size == 1 -> DownloadReconnectSelection.Automatic(indexes.single(), strongest)
+				else -> DownloadReconnectSelection.Ambiguous(strongest, indexes)
+			}
+		}
+
+		private fun rank(match: DownloadedContentMatch): Int = when (match) {
+			DownloadedContentMatch.NONE -> 0
+			DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL -> 1
+			DownloadedContentMatch.PUBLIC_URL -> 2
+			DownloadedContentMatch.EXACT_ID -> 3
+		}
+	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlanner.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlanner.kt
@@ -1,0 +1,75 @@
+package org.koitharu.kotatsu.sources.compat
+
+import org.koitharu.kotatsu.parsers.model.Manga
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+sealed interface DownloadReconnectPlan {
+	data object NoSafeMatch : DownloadReconnectPlan
+
+	data class Automatic(
+		val manga: Manga,
+		val evidence: DownloadedContentMatch,
+	) : DownloadReconnectPlan
+
+	/** More than one candidate has the same strongest evidence, so user confirmation is required. */
+	data class Ambiguous(
+		val evidence: DownloadedContentMatch,
+		val candidates: List<Manga>,
+	) : DownloadReconnectPlan
+}
+
+/**
+ * Chooses an existing downloaded copy only when identity evidence is unique and deterministic.
+ * Title similarity is deliberately excluded from automatic decisions.
+ */
+@Singleton
+class DownloadReconnectPlanner @Inject constructor(
+	private val matcher: DownloadedContentMatcher,
+) {
+
+	suspend fun plan(remote: Manga, downloadedCandidates: Iterable<Manga>): DownloadReconnectPlan {
+		var strongest = DownloadedContentMatch.NONE
+		val strongestCandidates = ArrayList<Manga>()
+		for (candidate in downloadedCandidates) {
+			val evidence = matcher.match(remote, candidate)
+			val comparison = rank(evidence).compareTo(rank(strongest))
+			when {
+				comparison > 0 -> {
+					strongest = evidence
+					strongestCandidates.clear()
+					if (evidence != DownloadedContentMatch.NONE) strongestCandidates += candidate
+				}
+				comparison == 0 && evidence != DownloadedContentMatch.NONE -> strongestCandidates += candidate
+			}
+		}
+		return when {
+			strongestCandidates.isEmpty() -> DownloadReconnectPlan.NoSafeMatch
+			strongestCandidates.size == 1 -> DownloadReconnectPlan.Automatic(strongestCandidates.single(), strongest)
+			else -> DownloadReconnectPlan.Ambiguous(strongest, strongestCandidates)
+		}
+	}
+
+	/**
+	 * Weak title matches are candidates for a manual reconnect screen only. Calling this function
+	 * never changes provider identity, database rows, or download files.
+	 */
+	fun manualTitleCandidates(remote: Manga, downloadedCandidates: Iterable<Manga>): List<Manga> {
+		val title = normalizeTitle(remote.title)
+		if (title.isEmpty()) return emptyList()
+		return downloadedCandidates.filter { normalizeTitle(it.title) == title }
+	}
+
+	private fun rank(match: DownloadedContentMatch): Int = when (match) {
+		DownloadedContentMatch.NONE -> 0
+		DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL -> 1
+		DownloadedContentMatch.PUBLIC_URL -> 2
+		DownloadedContentMatch.EXACT_ID -> 3
+	}
+
+	private fun normalizeTitle(value: String): String = value
+		.trim()
+		.lowercase(Locale.ROOT)
+		.replace(Regex("\\s+"), " ")
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlanner.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlanner.kt
@@ -43,11 +43,14 @@ class DownloadReconnectPlanner @Inject constructor(
 	private val matcher: DownloadedContentMatcher,
 ) {
 
+	/** Evaluate one candidate without retaining or mutating it. Useful for bounded fallback scans. */
+	suspend fun evidence(remote: Manga, downloaded: Manga): DownloadedContentMatch = matcher.match(remote, downloaded)
+
 	suspend fun plan(remote: Manga, downloadedCandidates: Iterable<Manga>): DownloadReconnectPlan {
 		val candidates = downloadedCandidates.toList()
 		val matches = ArrayList<DownloadedContentMatch>(candidates.size)
 		for (candidate in candidates) {
-			matches += matcher.match(remote, candidate)
+			matches += evidence(remote, candidate)
 		}
 		return when (val selection = select(matches)) {
 			DownloadReconnectSelection.NoSafeMatch -> DownloadReconnectPlan.NoSafeMatch

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadedContentMatcher.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/DownloadedContentMatcher.kt
@@ -1,0 +1,116 @@
+package org.koitharu.kotatsu.sources.compat
+
+import org.koitharu.kotatsu.parsers.model.Manga
+import java.net.URI
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class DownloadedContentMatch {
+	NONE,
+	EXACT_ID,
+	PUBLIC_URL,
+	SOURCE_ALIAS_AND_CONTENT_URL,
+}
+
+/**
+ * Non-destructive matcher for reconnecting a remote manga to an existing downloaded copy.
+ *
+ * This deliberately stops before title/chapter fuzzy matching. A title is presentation data, not
+ * identity; title-based candidates belong in a manual reconnect UI and must never auto-adopt files.
+ */
+@Singleton
+class DownloadedContentMatcher @Inject constructor(
+	private val sourceAliasRegistry: SourceAliasRegistry,
+) {
+
+	suspend fun match(remote: Manga, downloaded: Manga): DownloadedContentMatch {
+		val remoteSource = if (remote.id == downloaded.id ||
+			normalizePublicUrl(remote.publicUrl)?.let { it == normalizePublicUrl(downloaded.publicUrl) } == true
+		) {
+			null
+		} else {
+			sourceAliasRegistry.canonicalId(remote.source.name)
+		}
+		val downloadedSource = if (remoteSource == null) null else sourceAliasRegistry.canonicalId(downloaded.source.name)
+		return classify(
+			remoteId = remote.id,
+			downloadedId = downloaded.id,
+			remotePublicUrl = remote.publicUrl,
+			downloadedPublicUrl = downloaded.publicUrl,
+			remoteCanonicalSource = remoteSource,
+			downloadedCanonicalSource = downloadedSource,
+			remoteContentUrl = remote.url,
+			downloadedContentUrl = downloaded.url,
+		)
+	}
+
+	companion object {
+		internal fun classify(
+			remoteId: Long,
+			downloadedId: Long,
+			remotePublicUrl: String?,
+			downloadedPublicUrl: String?,
+			remoteCanonicalSource: CanonicalSourceId?,
+			downloadedCanonicalSource: CanonicalSourceId?,
+			remoteContentUrl: String?,
+			downloadedContentUrl: String?,
+		): DownloadedContentMatch {
+			if (remoteId == downloadedId) return DownloadedContentMatch.EXACT_ID
+
+			val remotePublic = normalizePublicUrl(remotePublicUrl)
+			val downloadedPublic = normalizePublicUrl(downloadedPublicUrl)
+			if (remotePublic != null && remotePublic == downloadedPublic) {
+				return DownloadedContentMatch.PUBLIC_URL
+			}
+
+			if (remoteCanonicalSource == null || remoteCanonicalSource != downloadedCanonicalSource) {
+				return DownloadedContentMatch.NONE
+			}
+			val remoteContent = normalizeContentUrl(remoteContentUrl)
+			val downloadedContent = normalizeContentUrl(downloadedContentUrl)
+			return if (remoteContent != null && remoteContent == downloadedContent) {
+				DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL
+			} else {
+				DownloadedContentMatch.NONE
+			}
+		}
+
+		internal fun normalizeContentUrl(value: String?): String? = value
+			?.trim()
+			?.takeIf(String::isNotEmpty)
+			?.trimEnd('/')
+			?.takeIf(String::isNotEmpty)
+
+		/**
+		 * Normalize only semantics that are safe for identity: HTTP(S) scheme/host case, default port,
+		 * a trailing slash, and fragment. Query parameters are retained because some sources use them
+		 * as the actual content key.
+		 */
+		internal fun normalizePublicUrl(value: String?): String? {
+			val raw = value?.trim()?.takeIf(String::isNotEmpty) ?: return null
+			val uri = runCatching { URI(raw) }.getOrNull() ?: return null
+			val scheme = uri.scheme?.lowercase(Locale.ROOT) ?: return null
+			if (scheme != "http" && scheme != "https") return null
+			val host = uri.host?.lowercase(Locale.ROOT) ?: return null
+			val effectivePort = when {
+				uri.port < 0 -> -1
+				scheme == "http" && uri.port == 80 -> -1
+				scheme == "https" && uri.port == 443 -> -1
+				else -> uri.port
+			}
+			val path = uri.rawPath.orEmpty().let { path ->
+				if (path.length > 1) path.trimEnd('/') else path
+			}
+			return URI(
+				scheme,
+				uri.rawUserInfo,
+				host,
+				effectivePort,
+				path,
+				uri.rawQuery,
+				null,
+			).toASCIIString()
+		}
+	}
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/SourceAliasRegistry.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sources/compat/SourceAliasRegistry.kt
@@ -1,0 +1,39 @@
+package org.koitharu.kotatsu.sources.compat
+
+import org.koitharu.kotatsu.kotatsumigration.data.KotatsuSourceMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Resolves persisted source names to stable canonical identities without changing the persisted
+ * value itself. This is intentionally metadata-only: resolution never loads an extension/plugin,
+ * touches download files, or performs network work.
+ *
+ * Legacy Kotatsu parser names reuse the existing, domain-derived [KotatsuSourceMap]. A legacy name
+ * and its Mihon/Keiyoushi target therefore receive the same `catalogue:<sourceId>` identity. Other
+ * providers remain isolated until an explicit compatibility mapping exists; guessing from display
+ * names is forbidden because unrelated sites can share the same title.
+ */
+@Singleton
+class SourceAliasRegistry @Inject constructor(
+	private val kotatsuSourceMap: KotatsuSourceMap,
+) {
+
+	suspend fun resolve(storedName: String): CanonicalSourceIdentity {
+		val direct = StoredSourceIdentity.direct(storedName)
+		if (direct.backend != SourceBackend.KOTATSU) return direct
+
+		val target = kotatsuSourceMap.resolve(direct.storedName) ?: return direct
+		return StoredSourceIdentity.mappedLegacy(
+			storedName = direct.storedName,
+			catalogueSourceId = target.sourceId,
+			sourceName = target.sourceName,
+			packageName = target.packageName,
+		)
+	}
+
+	suspend fun canonicalId(storedName: String): CanonicalSourceId = resolve(storedName).canonicalId
+
+	suspend fun areAliases(firstStoredName: String, secondStoredName: String): Boolean =
+		canonicalId(firstStoredName) == canonicalId(secondStoredName)
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/TsukiPluginInstaller.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/TsukiPluginInstaller.kt
@@ -45,6 +45,7 @@ class TsukiPluginInstaller @Inject constructor(
 	)
 
 	fun isStageAvailable(provider: TsukiPluginProvider): Boolean = when (provider) {
+		TsukiPluginProvider.MIYORARE -> false
 		TsukiPluginProvider.UMA,
 		TsukiPluginProvider.GEKKOUSHI,
 		TsukiPluginProvider.CUSTOM,
@@ -299,6 +300,7 @@ class TsukiPluginInstaller @Inject constructor(
 		.ifBlank { "custom" }
 
 	private fun knownProvider(provider: TsukiPluginProvider): ProviderConfig? = when (provider) {
+		TsukiPluginProvider.MIYORARE -> null
 		TsukiPluginProvider.UMA -> ProviderConfig(
 			provider = provider,
 			pluginId = "uma",

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/model/TsukiPluginModels.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/model/TsukiPluginModels.kt
@@ -3,8 +3,10 @@ package org.koitharu.kotatsu.tsuki.model
 import android.net.Uri
 import org.koitharu.kotatsu.parsers.model.MangaSource
 
-/** Third-party ecosystem that supplied a Tsuki/Usagi plugin. */
+/** Ecosystem that supplied a Tsuki/Usagi-compatible plugin. */
 enum class TsukiPluginProvider(val wireName: String) {
+	/** Official Miyorare source packs, e.g. Miyorare-ID and Miyorare-EN. */
+	MIYORARE("MIYORARE"),
 	UMA("UMA"),
 	GEKKOUSHI("GEKKOUSHI"),
 	CUSTOM("CUSTOM");

--- a/app/src/test/kotlin/org/koitharu/kotatsu/local/data/index/DownloadPathAliasTest.kt
+++ b/app/src/test/kotlin/org/koitharu/kotatsu/local/data/index/DownloadPathAliasTest.kt
@@ -1,0 +1,25 @@
+package org.koitharu.kotatsu.local.data.index
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DownloadPathAliasTest {
+
+	@Test
+	fun `alias round trips paths containing separator characters`() {
+		val alias = DownloadPathAlias(
+			localMangaId = 42L,
+			path = "/storage/emulated/0/Miyorare/downloads/Source/A|B",
+		)
+		assertEquals(alias, DownloadPathAlias.parse(alias.serialize()))
+	}
+
+	@Test
+	fun `malformed aliases are rejected`() {
+		assertNull(DownloadPathAlias.parse(null))
+		assertNull(DownloadPathAlias.parse(""))
+		assertNull(DownloadPathAlias.parse("abc|/path"))
+		assertNull(DownloadPathAlias.parse("42|"))
+	}
+}

--- a/app/src/test/kotlin/org/koitharu/kotatsu/settings/sources/migration/LibrarySourceOptionTest.kt
+++ b/app/src/test/kotlin/org/koitharu/kotatsu/settings/sources/migration/LibrarySourceOptionTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class LibrarySourceOptionTest {
 
 	@Test
-	fun `same displayed source merges raw keys and counts`() {
+	fun `same canonical source merges raw keys and counts`() {
 		val merged = mergeLibrarySourceOptions(
 			listOf(
 				option(key = "LEGACY_HITOMI", title = "Hitomi", count = 2, unavailable = true, sourceId = 123),
@@ -34,12 +34,25 @@ class LibrarySourceOptionTest {
 		assertEquals(2, merged.size)
 	}
 
+	@Test
+	fun `same display title without verified alias stays separate`() {
+		val merged = mergeLibrarySourceOptions(
+			listOf(
+				option("TSUKI:UMA:uma:Example", "Example", 2, false, canonicalKey = "provider:tsuki:UMA:uma:Example"),
+				option("SOME_LEGACY_EXAMPLE", "Example", 3, true, canonicalKey = "kotatsu:SOME_LEGACY_EXAMPLE"),
+			),
+		)
+
+		assertEquals(2, merged.size)
+	}
+
 	private fun option(
 		key: String,
 		title: String,
 		count: Int,
 		unavailable: Boolean,
 		sourceId: Long? = null,
+		canonicalKey: String = sourceId?.let { "catalogue:$it" } ?: "stored:$key",
 	) = LibrarySourceOption(
 		key = key,
 		sourceKeys = setOf(key),
@@ -49,5 +62,6 @@ class LibrarySourceOptionTest {
 		iconSourceKey = key,
 		iconUrl = null,
 		sourceId = sourceId,
+		canonicalKey = canonicalKey,
 	)
 }

--- a/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlannerTest.kt
+++ b/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlannerTest.kt
@@ -5,13 +5,9 @@ import org.junit.Test
 
 class DownloadReconnectPlannerTest {
 
-	private val planner = DownloadReconnectPlanner(
-		matcher = error("Matcher is not used by pure selection tests"),
-	)
-
 	@Test
 	fun `unique strongest evidence is selected automatically`() {
-		val result = planner.select(
+		val result = DownloadReconnectPlanner.select(
 			listOf(
 				DownloadedContentMatch.NONE,
 				DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL,
@@ -26,7 +22,7 @@ class DownloadReconnectPlannerTest {
 
 	@Test
 	fun `same strongest evidence is ambiguous`() {
-		val result = planner.select(
+		val result = DownloadReconnectPlanner.select(
 			listOf(
 				DownloadedContentMatch.PUBLIC_URL,
 				DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL,
@@ -44,7 +40,7 @@ class DownloadReconnectPlannerTest {
 
 	@Test
 	fun `weaker duplicates do not make a stronger candidate ambiguous`() {
-		val result = planner.select(
+		val result = DownloadReconnectPlanner.select(
 			listOf(
 				DownloadedContentMatch.PUBLIC_URL,
 				DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL,
@@ -59,7 +55,7 @@ class DownloadReconnectPlannerTest {
 
 	@Test
 	fun `no identity evidence never auto reconnects`() {
-		val result = planner.select(
+		val result = DownloadReconnectPlanner.select(
 			listOf(
 				DownloadedContentMatch.NONE,
 				DownloadedContentMatch.NONE,

--- a/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlannerTest.kt
+++ b/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/DownloadReconnectPlannerTest.kt
@@ -1,0 +1,70 @@
+package org.koitharu.kotatsu.sources.compat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadReconnectPlannerTest {
+
+	private val planner = DownloadReconnectPlanner(
+		matcher = error("Matcher is not used by pure selection tests"),
+	)
+
+	@Test
+	fun `unique strongest evidence is selected automatically`() {
+		val result = planner.select(
+			listOf(
+				DownloadedContentMatch.NONE,
+				DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL,
+				DownloadedContentMatch.PUBLIC_URL,
+			),
+		)
+		assertEquals(
+			DownloadReconnectSelection.Automatic(2, DownloadedContentMatch.PUBLIC_URL),
+			result,
+		)
+	}
+
+	@Test
+	fun `same strongest evidence is ambiguous`() {
+		val result = planner.select(
+			listOf(
+				DownloadedContentMatch.PUBLIC_URL,
+				DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL,
+				DownloadedContentMatch.PUBLIC_URL,
+			),
+		)
+		assertEquals(
+			DownloadReconnectSelection.Ambiguous(
+				DownloadedContentMatch.PUBLIC_URL,
+				listOf(0, 2),
+			),
+			result,
+		)
+	}
+
+	@Test
+	fun `weaker duplicates do not make a stronger candidate ambiguous`() {
+		val result = planner.select(
+			listOf(
+				DownloadedContentMatch.PUBLIC_URL,
+				DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL,
+				DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL,
+			),
+		)
+		assertEquals(
+			DownloadReconnectSelection.Automatic(0, DownloadedContentMatch.PUBLIC_URL),
+			result,
+		)
+	}
+
+	@Test
+	fun `no identity evidence never auto reconnects`() {
+		val result = planner.select(
+			listOf(
+				DownloadedContentMatch.NONE,
+				DownloadedContentMatch.NONE,
+			),
+		)
+		assertEquals(DownloadReconnectSelection.NoSafeMatch, result)
+	}
+}

--- a/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/DownloadedContentMatcherTest.kt
+++ b/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/DownloadedContentMatcherTest.kt
@@ -1,0 +1,75 @@
+package org.koitharu.kotatsu.sources.compat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadedContentMatcherTest {
+
+	@Test
+	fun `exact id remains strongest match`() {
+		val result = DownloadedContentMatcher.classify(
+			remoteId = 42,
+			downloadedId = 42,
+			remotePublicUrl = "https://new.example/manga",
+			downloadedPublicUrl = "https://old.example/manga",
+			remoteCanonicalSource = CanonicalSourceId("provider:new"),
+			downloadedCanonicalSource = CanonicalSourceId("provider:old"),
+			remoteContentUrl = "/new",
+			downloadedContentUrl = "/old",
+		)
+		assertEquals(DownloadedContentMatch.EXACT_ID, result)
+	}
+
+	@Test
+	fun `public url reconnects across provider ids and harmless url formatting`() {
+		val result = DownloadedContentMatcher.classify(
+			remoteId = 1,
+			downloadedId = 2,
+			remotePublicUrl = "HTTPS://Example.COM:443/title/abc/#reader",
+			downloadedPublicUrl = "https://example.com/title/abc",
+			remoteCanonicalSource = CanonicalSourceId("provider:new"),
+			downloadedCanonicalSource = CanonicalSourceId("provider:old"),
+			remoteContentUrl = "/new-id",
+			downloadedContentUrl = "/old-id",
+		)
+		assertEquals(DownloadedContentMatch.PUBLIC_URL, result)
+	}
+
+	@Test
+	fun `verified source alias and same content url reconnect`() {
+		val canonical = CanonicalSourceId("catalogue:123")
+		val result = DownloadedContentMatcher.classify(
+			remoteId = 1,
+			downloadedId = 2,
+			remotePublicUrl = null,
+			downloadedPublicUrl = null,
+			remoteCanonicalSource = canonical,
+			downloadedCanonicalSource = canonical,
+			remoteContentUrl = "/manga/abc/",
+			downloadedContentUrl = "/manga/abc",
+		)
+		assertEquals(DownloadedContentMatch.SOURCE_ALIAS_AND_CONTENT_URL, result)
+	}
+
+	@Test
+	fun `same content url under unrelated providers never auto reconnects`() {
+		val result = DownloadedContentMatcher.classify(
+			remoteId = 1,
+			downloadedId = 2,
+			remotePublicUrl = null,
+			downloadedPublicUrl = null,
+			remoteCanonicalSource = CanonicalSourceId("provider:one"),
+			downloadedCanonicalSource = CanonicalSourceId("provider:two"),
+			remoteContentUrl = "/manga/abc",
+			downloadedContentUrl = "/manga/abc",
+		)
+		assertEquals(DownloadedContentMatch.NONE, result)
+	}
+
+	@Test
+	fun `query is retained because it may be the content key`() {
+		val first = DownloadedContentMatcher.normalizePublicUrl("https://example.com/read?id=1")
+		val second = DownloadedContentMatcher.normalizePublicUrl("https://example.com/read?id=2")
+		assertEquals(false, first == second)
+	}
+}

--- a/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/StoredSourceIdentityTest.kt
+++ b/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/StoredSourceIdentityTest.kt
@@ -1,0 +1,60 @@
+package org.koitharu.kotatsu.sources.compat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StoredSourceIdentityTest {
+
+	@Test
+	fun `mihon stored identity uses catalogue id instead of display name`() {
+		val first = StoredSourceIdentity.direct("MIHON_123:Hitomi")
+		val second = StoredSourceIdentity.direct("MIHON_123:Hitomi English")
+
+		assertEquals(CanonicalSourceId("catalogue:123"), first.canonicalId)
+		assertEquals(first.canonicalId, second.canonicalId)
+		assertEquals(SourceBackend.MIHON, first.backend)
+		assertEquals(123L, first.catalogueSourceId)
+	}
+
+	@Test
+	fun `legacy mapping resolves to same catalogue identity without rewriting stored name`() {
+		val legacy = StoredSourceIdentity.mappedLegacy(
+			storedName = "MANGADEX",
+			catalogueSourceId = 2499283573021220255L,
+			sourceName = "MangaDex",
+			packageName = "eu.kanade.tachiyomi.extension.all.mangadex",
+		)
+		val mihon = StoredSourceIdentity.direct("MIHON_2499283573021220255:MangaDex")
+
+		assertEquals(mihon.canonicalId, legacy.canonicalId)
+		assertEquals("MANGADEX", legacy.storedName)
+		assertTrue(legacy.isAlias)
+	}
+
+	@Test
+	fun `tsuki providers stay isolated until an explicit alias exists`() {
+		val uma = StoredSourceIdentity.direct("TSUKI:UMA:uma:MangaDex")
+		val custom = StoredSourceIdentity.direct("TSUKI:CUSTOM:other:MangaDex")
+
+		assertEquals(SourceBackend.TSUKI, uma.backend)
+		assertFalse(uma.canonicalId == custom.canonicalId)
+	}
+
+	@Test
+	fun `official miyorare namespace is reserved independently of third party providers`() {
+		val official = StoredSourceIdentity.direct("MIYORARE:en:mangadex")
+		val thirdParty = StoredSourceIdentity.direct("TSUKI:UMA:uma:MangaDex")
+
+		assertEquals(SourceBackend.MIYORARE, official.backend)
+		assertEquals(CanonicalSourceId("miyorare:en:mangadex"), official.canonicalId)
+		assertFalse(official.canonicalId == thirdParty.canonicalId)
+	}
+
+	@Test
+	fun `internal sources never collide with provider sources`() {
+		assertEquals(CanonicalSourceId("internal:local"), StoredSourceIdentity.direct("LOCAL").canonicalId)
+		assertEquals(CanonicalSourceId("internal:unknown"), StoredSourceIdentity.direct("UNKNOWN").canonicalId)
+	}
+}

--- a/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/StoredSourceIdentityTest.kt
+++ b/app/src/test/kotlin/org/koitharu/kotatsu/sources/compat/StoredSourceIdentityTest.kt
@@ -44,12 +44,15 @@ class StoredSourceIdentityTest {
 
 	@Test
 	fun `official miyorare namespace is reserved independently of third party providers`() {
-		val official = StoredSourceIdentity.direct("MIYORARE:en:mangadex")
+		val direct = StoredSourceIdentity.direct("MIYORARE:en:mangadex")
+		val pack = StoredSourceIdentity.direct("TSUKI:MIYORARE:miyorare-en:MangaDex")
 		val thirdParty = StoredSourceIdentity.direct("TSUKI:UMA:uma:MangaDex")
 
-		assertEquals(SourceBackend.MIYORARE, official.backend)
-		assertEquals(CanonicalSourceId("miyorare:en:mangadex"), official.canonicalId)
-		assertFalse(official.canonicalId == thirdParty.canonicalId)
+		assertEquals(SourceBackend.MIYORARE, direct.backend)
+		assertEquals(CanonicalSourceId("miyorare:en:mangadex"), direct.canonicalId)
+		assertEquals(SourceBackend.MIYORARE, pack.backend)
+		assertEquals(CanonicalSourceId("miyorare:miyorare-en:MangaDex"), pack.canonicalId)
+		assertFalse(pack.canonicalId == thirdParty.canonicalId)
 	}
 
 	@Test

--- a/docs/source-compatibility.md
+++ b/docs/source-compatibility.md
@@ -1,0 +1,73 @@
+# Miyorare Source Compatibility Foundation
+
+This document defines the invariants for the Miyorare-owned source ecosystem. The implementation must preserve these rules while Miyorare-ID and Miyorare-EN are introduced.
+
+## Goals
+
+- Keep the app core fast and usable when no optional provider is installed.
+- Support the existing Mihon/Keiyoushi-compatible APK path, Tsuki/Usagi JAR path (including UMA/Gekkoushi), LNReader plugins, and Kotatsu parsers without creating another competing loader.
+- Add an official `MIYORARE:` namespace for future Miyorare source packs.
+- Treat provider identity and user content identity as different concepts.
+
+## Canonical identity
+
+Persisted provider keys remain unchanged. `SourceAliasRegistry` computes a provider-neutral canonical identity in memory.
+
+Current safe mappings:
+
+- `MIHON_<sourceId>:...` -> `catalogue:<sourceId>`
+- a legacy Kotatsu source that `KotatsuSourceMap` maps to that same Mihon source -> `catalogue:<sourceId>`
+- `TSUKI:...` -> provider-local identity until an explicit cross-provider alias is supplied
+- `LN_...` -> provider-local identity
+- `MIYORARE:...` -> official Miyorare identity
+
+Display names are never used as proof that two sources are identical.
+
+## User-data invariants
+
+Changing or disabling a provider must not by itself:
+
+- delete or move CBZ/ZIP/PDF/EPUB files;
+- trigger a redownload;
+- delete favourites, categories, notes, history, bookmarks, or reading progress;
+- turn a downloaded chapter unreadable solely because its remote chapter disappeared;
+- silently rewrite a stored source key before a migration has been validated.
+
+Provider migration must resolve existing content in this order where data is available:
+
+1. canonical content/source identity;
+2. explicit source alias;
+3. stable/public manga URL or provider content key;
+4. download metadata;
+5. existing legacy folder/path metadata;
+6. normalized title + chapter fallback;
+7. preserve as an unlinked/orphaned download and offer manual reconnect.
+
+The fallback stages must be non-destructive. A weaker match may suggest a reconnect but must not delete the original data.
+
+## Performance rules
+
+- Source identity resolution is metadata-only and must not load plugin classes or perform network requests.
+- Tsuki runtime remains lazy; do not add another JAR class loader.
+- Existing Mihon extension runtime remains the Keiyoushi-compatible APK path; do not duplicate it with a second APK loader.
+- Large source packs must opt sources into Explore/global search rather than enabling every parser automatically.
+
+## Source packs
+
+The intended official packs are initially:
+
+- `Miyorare-ID`
+- `Miyorare-EN`
+
+They should be shipped separately from the app APK and use the existing Tsuki-compatible plugin host unless a later measured requirement proves that a different ABI is necessary. A source pack update should not require a Miyorare app update when the host ABI remains compatible.
+
+Third-party code keeps its original license and attribution. Copying/adapting a parser does not remove those obligations.
+
+## Rollout
+
+1. Canonical identity + alias registry (this foundation).
+2. Use canonical identities in source migration/reconnect UI.
+3. Add download resolver metadata/fallbacks without moving existing files.
+4. Add official Miyorare provider metadata/signing/update channel.
+5. Build small EN/ID packs by adapting proven parsers, then expand via compatibility tests rather than enabling every imported source at once.
+6. Add explicit cross-provider aliases only when the equivalence is verified; never infer them from a display name alone.

--- a/extensions/miyorare-sources/ATTRIBUTION.md
+++ b/extensions/miyorare-sources/ATTRIBUTION.md
@@ -1,0 +1,24 @@
+# Miyorare Sources — Attribution
+
+This directory stages Miyorare-owned Tsuki source packs. It does not claim ownership of the
+third-party websites exposed by a parser.
+
+## Upstream parser code
+
+The initial curated packs are built from source code in **InvalidDavid/UMA**, pinned to the exact
+commit recorded in `packs.json`. UMA is distributed under **GNU GPL v3.0** and is itself derived
+from other open-source parser work. Miyorare keeps the upstream license and source provenance when
+adapting or distributing that code.
+
+Upstream repository: `https://github.com/InvalidDavid/UMA`
+
+The build workflow injects the upstream `LICENSE` file and `miyorare-pack.json` provenance metadata
+into every staging JAR. Any future code imported from a differently licensed project (for example,
+Apache-2.0 code from Keiyoushi) must retain that project's required license/notice information as
+well.
+
+## Content providers
+
+Parser/source support does not imply affiliation with, endorsement by, or ownership of the websites
+or content providers that a parser can access. Users remain responsible for complying with the
+applicable provider terms and local law.

--- a/extensions/miyorare-sources/README.md
+++ b/extensions/miyorare-sources/README.md
@@ -1,0 +1,39 @@
+# Miyorare Source Packs (staging)
+
+This directory is the reproducible staging area for the first official Miyorare Tsuki source packs:
+
+- `miyorare-id` — curated Indonesian sources
+- `miyorare-en` — curated English sources
+
+The packs are **not bundled into the Miyorare APK**. They target the existing Tsuki 1.0.5 plugin
+runtime and are intended to be installed on demand under the `MIYORARE` provider identity.
+
+## Why this is separate from the app
+
+Source websites change much more often than the Miyorare core. Keeping parser packs separate lets
+source fixes ship without touching Reader, Downloads, Explore, Favourites, startup, or navigation
+code. Installing a large pack also does not enable every source automatically; the host keeps source
+visibility as an explicit user choice.
+
+## Reproducible upstream import
+
+`packs.json` pins the exact upstream repository and commit. `tools/prepare_pack.py` verifies that
+checkout before removing every non-target language and every source file not present in the curated
+whitelist. Shared parser/util code is retained because many small source declarations depend on it.
+KSP then generates the Tsuki source enum/factory from only the remaining annotated source classes.
+
+A source is never added merely because it appears upstream. It must first be added to a pack's
+whitelist and pass the pack build. Runtime health/network behavior is a separate acceptance gate
+before the pack is treated as stable.
+
+## Download compatibility
+
+Changing provider does not move or rewrite existing download files. Miyorare's core compatibility
+layer resolves strong identity evidence and stores a non-destructive alias from the new remote manga
+ID to the existing local path. Ambiguous matches are not auto-linked.
+
+## Licensing
+
+See `ATTRIBUTION.md`. Upstream GPL source and license/provenance are preserved in staging artifacts.
+Parser availability does not imply affiliation with third-party websites or ownership of their
+content.

--- a/extensions/miyorare-sources/packs.json
+++ b/extensions/miyorare-sources/packs.json
@@ -1,0 +1,49 @@
+{
+  "schema": 1,
+  "tsukiApi": "1.0.5",
+  "upstream": {
+    "name": "UMA",
+    "repository": "InvalidDavid/UMA",
+    "commit": "a0ebc9ffc7de02b7b50cbcb620092d0a9263c785",
+    "license": "GPL-3.0"
+  },
+  "packs": {
+    "id": {
+      "pluginId": "miyorare-id",
+      "displayName": "Miyorare Indonesia",
+      "language": "id",
+      "assetName": "miyorare-id.jar",
+      "sources": [
+        "AinzScans.kt",
+        "Apkomik.kt",
+        "Bacami.kt",
+        "CGBUM.kt",
+        "CosmicScans.kt",
+        "Ikiru.kt",
+        "Kiryuu.kt",
+        "Komiku.kt",
+        "LumosKomik.kt",
+        "MGKomik.kt",
+        "ReYume.kt"
+      ]
+    },
+    "en": {
+      "pluginId": "miyorare-en",
+      "displayName": "Miyorare English",
+      "language": "en",
+      "assetName": "miyorare-en.jar",
+      "sources": [
+        "AnisaScans.kt",
+        "AquaReader.kt",
+        "AsuraScan.kt",
+        "Atsumaru.kt",
+        "Batcave.kt",
+        "Chikari.kt",
+        "DemonicScan.kt",
+        "DragonTea.kt",
+        "DynastyScans.kt",
+        "EnThunderScans.kt"
+      ]
+    }
+  }
+}

--- a/extensions/miyorare-sources/tools/finalize_pack.py
+++ b/extensions/miyorare-sources/tools/finalize_pack.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Verify, attribute and finalize a curated Miyorare source-pack JAR."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import zipfile
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--upstream", type=Path, required=True)
+    parser.add_argument("--pack", choices=("id", "en"), required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    pack = manifest["packs"][args.pack]
+    expected_count = len(pack["sources"])
+
+    summary = args.upstream / ".github/summary.yaml"
+    if not summary.is_file():
+        fail("KSP summary.yaml was not generated")
+    summary_line = summary.read_text(encoding="utf-8").strip()
+    try:
+        actual_count = int(summary_line.split(":", 1)[1].strip())
+    except (IndexError, ValueError):
+        fail(f"Unexpected KSP summary: {summary_line!r}")
+    if actual_count != expected_count:
+        fail(f"KSP exposed {actual_count} sources; manifest expects {expected_count}")
+
+    built = args.upstream / "build/libs/uma.jar"
+    if not built.is_file() or built.stat().st_size == 0:
+        fail("UMA build did not produce build/libs/uma.jar")
+
+    with zipfile.ZipFile(built, "r") as archive:
+        names = set(archive.namelist())
+    if "classes.dex" not in names:
+        fail("Built plugin is not a dexed Tsuki JAR (classes.dex missing)")
+
+    license_file = args.upstream / "LICENSE"
+    provenance_file = args.upstream / "miyorare-pack.json"
+    if not license_file.is_file() or not provenance_file.is_file():
+        fail("Required license/provenance metadata is missing")
+
+    # JAR is a ZIP container. Add provenance resources without modifying classes.dex.
+    with zipfile.ZipFile(built, "a", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(
+            "META-INF/licenses/UMA-GPL-3.0.txt",
+            license_file.read_text(encoding="utf-8"),
+        )
+        archive.writestr(
+            "META-INF/miyorare-pack.json",
+            provenance_file.read_text(encoding="utf-8"),
+        )
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    final_jar = args.output / pack["assetName"]
+    shutil.copy2(built, final_jar)
+    digest = hashlib.sha256(final_jar.read_bytes()).hexdigest()
+    (args.output / f"{pack['assetName']}.sha256").write_text(
+        f"{digest}  {pack['assetName']}\n",
+        encoding="utf-8",
+    )
+    shutil.copy2(provenance_file, args.output / f"{args.pack}-pack.json")
+    print(f"Finalized {final_jar} ({expected_count} sources, sha256={digest})")
+
+
+if __name__ == "__main__":
+    main()

--- a/extensions/miyorare-sources/tools/finalize_pack.py
+++ b/extensions/miyorare-sources/tools/finalize_pack.py
@@ -6,13 +6,28 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import shutil
 import zipfile
 from pathlib import Path
 
 
+GENERATED_SOURCE_RE = re.compile(
+    r'^\s*(?:@Deprecated\("(?:\\.|[^"\\])*"\)\s*)?([A-Z_][A-Z0-9_]{3,})\(',
+    re.MULTILINE,
+)
+
+
 def fail(message: str) -> None:
     raise SystemExit(message)
+
+
+def generated_source_file(upstream: Path) -> Path:
+    generated_root = upstream / "build/generated/ksp"
+    candidates = list(generated_root.rglob("MangaSource.kt")) if generated_root.is_dir() else []
+    if len(candidates) != 1:
+        fail(f"Expected exactly one generated MangaSource.kt, found {len(candidates)}")
+    return candidates[0]
 
 
 def main() -> None:
@@ -25,18 +40,39 @@ def main() -> None:
 
     manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
     pack = manifest["packs"][args.pack]
-    expected_count = len(pack["sources"])
+    provenance_file = args.upstream / "miyorare-pack.json"
+    if not provenance_file.is_file():
+        fail("Prepared pack provenance metadata is missing")
+    provenance = json.loads(provenance_file.read_text(encoding="utf-8"))
+    expected_names = provenance.get("sourceNames") or []
+    expected_count = provenance.get("sourceCount")
+    if not expected_names or expected_count != len(expected_names):
+        fail("Prepared pack provenance has an invalid runtime source list")
+
+    generated = generated_source_file(args.upstream)
+    generated_names = GENERATED_SOURCE_RE.findall(generated.read_text(encoding="utf-8"))
+    if len(generated_names) != len(set(generated_names)):
+        fail("KSP generated duplicate runtime source names")
+    missing = sorted(set(expected_names) - set(generated_names))
+    unexpected = sorted(set(generated_names) - set(expected_names))
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected: {', '.join(unexpected)}")
+        fail("Generated KSP source set differs from curated provenance (" + "; ".join(details) + ")")
 
     summary = args.upstream / ".github/summary.yaml"
     if not summary.is_file():
         fail("KSP summary.yaml was not generated")
     summary_line = summary.read_text(encoding="utf-8").strip()
     try:
-        actual_count = int(summary_line.split(":", 1)[1].strip())
+        summary_count = int(summary_line.split(":", 1)[1].strip())
     except (IndexError, ValueError):
         fail(f"Unexpected KSP summary: {summary_line!r}")
-    if actual_count != expected_count:
-        fail(f"KSP exposed {actual_count} sources; manifest expects {expected_count}")
+    if summary_count != len(generated_names):
+        fail(f"KSP summary reports {summary_count}, generated enum contains {len(generated_names)}")
 
     built = args.upstream / "build/libs/uma.jar"
     if not built.is_file() or built.stat().st_size == 0:
@@ -48,9 +84,8 @@ def main() -> None:
         fail("Built plugin is not a dexed Tsuki JAR (classes.dex missing)")
 
     license_file = args.upstream / "LICENSE"
-    provenance_file = args.upstream / "miyorare-pack.json"
-    if not license_file.is_file() or not provenance_file.is_file():
-        fail("Required license/provenance metadata is missing")
+    if not license_file.is_file():
+        fail("Required upstream license is missing")
 
     # JAR is a ZIP container. Add provenance resources without modifying classes.dex.
     with zipfile.ZipFile(built, "a", compression=zipfile.ZIP_DEFLATED) as archive:
@@ -72,7 +107,10 @@ def main() -> None:
         encoding="utf-8",
     )
     shutil.copy2(provenance_file, args.output / f"{args.pack}-pack.json")
-    print(f"Finalized {final_jar} ({expected_count} sources, sha256={digest})")
+    print(
+        f"Finalized {final_jar} "
+        f"({provenance['sourceFilesCount']} files / {len(generated_names)} runtime sources, sha256={digest})"
+    )
 
 
 if __name__ == "__main__":

--- a/extensions/miyorare-sources/tools/prepare_pack.py
+++ b/extensions/miyorare-sources/tools/prepare_pack.py
@@ -9,13 +9,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
+from typing import NoReturn
 
 
-def fail(message: str) -> "NoReturn":
+ANNOTATION_RE = re.compile(r"@MangaSourceParser\s*\((.*?)\)", re.DOTALL)
+STRING_RE = re.compile(r'"((?:\\.|[^"\\])*)"')
+
+
+def fail(message: str) -> NoReturn:
     raise SystemExit(message)
 
 
@@ -39,6 +44,17 @@ def load_manifest(path: Path, pack_name: str) -> tuple[dict, dict]:
     if not isinstance(pack, dict):
         fail(f"Unknown pack: {pack_name}")
     return root, pack
+
+
+def parser_annotations(content: str, file_name: str) -> list[tuple[str, str]]:
+    """Return (runtime source name, locale) pairs declared by one curated Kotlin file."""
+    result: list[tuple[str, str]] = []
+    for match in ANNOTATION_RE.finditer(content):
+        strings = STRING_RE.findall(match.group(1))
+        if len(strings) < 3:
+            fail(f"Could not parse @MangaSourceParser arguments in {file_name}")
+        result.append((strings[0], strings[2]))
+    return result
 
 
 def prepare(manifest: Path, upstream: Path, pack_name: str) -> None:
@@ -83,14 +99,22 @@ def prepare(manifest: Path, upstream: Path, pack_name: str) -> None:
         if file.name not in keep:
             file.unlink()
 
-    # Fail before Gradle if a curated file clearly declares a different locale.
-    annotation_token = f'"{language}"'
+    # One Kotlin file can declare several runtime sources. Record the actual annotation names so the
+    # finalizer can compare KSP output exactly instead of incorrectly equating file count to source count.
+    source_names: list[str] = []
     for name in requested:
         content = (language_dir / name).read_text(encoding="utf-8")
-        if "@MangaSourceParser" not in content:
-            fail(f"{name} has no @MangaSourceParser annotation")
-        if annotation_token not in content:
-            fail(f"{name} does not appear to declare locale {language}")
+        annotations = parser_annotations(content, name)
+        if not annotations:
+            fail(f"{name} has no parseable @MangaSourceParser annotation")
+        for source_name, locale in annotations:
+            if locale != language:
+                fail(f"{name} declares {source_name} with locale {locale!r}, expected {language!r}")
+            source_names.append(source_name)
+
+    if len(source_names) != len(set(source_names)):
+        duplicates = sorted({name for name in source_names if source_names.count(name) > 1})
+        fail(f"Pack {pack_name} contains duplicate runtime source names: {', '.join(duplicates)}")
 
     metadata = {
         "schema": 1,
@@ -100,15 +124,17 @@ def prepare(manifest: Path, upstream: Path, pack_name: str) -> None:
         "assetName": pack["assetName"],
         "tsukiApi": root["tsukiApi"],
         "upstream": upstream_meta,
-        "sourceCount": len(requested),
-        "sources": requested,
+        "sourceFilesCount": len(requested),
+        "sourceCount": len(source_names),
+        "sourceFiles": requested,
+        "sourceNames": sorted(source_names),
     }
     (upstream / "miyorare-pack.json").write_text(
         json.dumps(metadata, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
     print(
-        f"Prepared {pack['displayName']} ({len(requested)} sources) from "
+        f"Prepared {pack['displayName']} ({len(requested)} files / {len(source_names)} runtime sources) from "
         f"{upstream_meta['repository']}@{expected_commit[:12]}"
     )
 

--- a/extensions/miyorare-sources/tools/prepare_pack.py
+++ b/extensions/miyorare-sources/tools/prepare_pack.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Prepare one curated Miyorare Tsuki source pack from a pinned UMA checkout.
+
+The upstream checkout is modified in place. The script never downloads anything itself: CI or the
+maintainer must provide the exact upstream checkout declared in packs.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> "NoReturn":
+    raise SystemExit(message)
+
+
+def git_head(repo: Path) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.STDOUT,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        fail(f"Could not read upstream git HEAD: {exc}")
+
+
+def load_manifest(path: Path, pack_name: str) -> tuple[dict, dict]:
+    root = json.loads(path.read_text(encoding="utf-8"))
+    if root.get("schema") != 1:
+        fail("Unsupported packs.json schema")
+    packs = root.get("packs") or {}
+    pack = packs.get(pack_name)
+    if not isinstance(pack, dict):
+        fail(f"Unknown pack: {pack_name}")
+    return root, pack
+
+
+def prepare(manifest: Path, upstream: Path, pack_name: str) -> None:
+    root, pack = load_manifest(manifest, pack_name)
+    upstream_meta = root["upstream"]
+    expected_commit = upstream_meta["commit"]
+    actual_commit = git_head(upstream)
+    if actual_commit != expected_commit:
+        fail(f"Upstream HEAD mismatch: expected {expected_commit}, got {actual_commit}")
+
+    site_root = upstream / "src/main/kotlin/tsuki/site"
+    if not site_root.is_dir():
+        fail(f"UMA site directory not found: {site_root}")
+
+    language = pack["language"]
+    language_dir = site_root / language
+    if not language_dir.is_dir():
+        fail(f"Language directory does not exist upstream: {language}")
+
+    requested = pack.get("sources") or []
+    if not requested or len(requested) != len(set(requested)):
+        fail(f"Pack {pack_name} must contain a non-empty unique source list")
+    if any(Path(name).name != name or not name.endswith(".kt") for name in requested):
+        fail(f"Pack {pack_name} contains an invalid source filename")
+
+    available = {file.name for file in language_dir.glob("*.kt") if file.is_file()}
+    missing = sorted(set(requested) - available)
+    if missing:
+        fail(f"Pack {pack_name} references missing upstream sources: {', '.join(missing)}")
+
+    # Remove every other language. Shared parser/util code remains untouched.
+    for child in list(site_root.iterdir()):
+        if child.name == language:
+            continue
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+    keep = set(requested)
+    for file in language_dir.glob("*.kt"):
+        if file.name not in keep:
+            file.unlink()
+
+    # Fail before Gradle if a curated file clearly declares a different locale.
+    annotation_token = f'"{language}"'
+    for name in requested:
+        content = (language_dir / name).read_text(encoding="utf-8")
+        if "@MangaSourceParser" not in content:
+            fail(f"{name} has no @MangaSourceParser annotation")
+        if annotation_token not in content:
+            fail(f"{name} does not appear to declare locale {language}")
+
+    metadata = {
+        "schema": 1,
+        "pluginId": pack["pluginId"],
+        "displayName": pack["displayName"],
+        "language": language,
+        "assetName": pack["assetName"],
+        "tsukiApi": root["tsukiApi"],
+        "upstream": upstream_meta,
+        "sourceCount": len(requested),
+        "sources": requested,
+    }
+    (upstream / "miyorare-pack.json").write_text(
+        json.dumps(metadata, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"Prepared {pack['displayName']} ({len(requested)} sources) from "
+        f"{upstream_meta['repository']}@{expected_commit[:12]}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--upstream", type=Path, required=True)
+    parser.add_argument("--pack", choices=("id", "en"), required=True)
+    args = parser.parse_args()
+    prepare(args.manifest.resolve(), args.upstream.resolve(), args.pack)
+
+
+if __name__ == "__main__":
+    main()

--- a/extensions/miyorare-sources/tools/prepare_pack.py
+++ b/extensions/miyorare-sources/tools/prepare_pack.py
@@ -57,6 +57,52 @@ def parser_annotations(content: str, file_name: str) -> list[tuple[str, str]]:
     return result
 
 
+def prune_unselected_parser_files(language_dir: Path, requested: list[str]) -> None:
+    """Remove parser declarations not selected by the pack, including nested source folders.
+
+    UMA keeps some sources in nested locale subdirectories. Removing only top-level ``*.kt`` files
+    leaves those parsers visible to KSP. Keep unannotated helper files so selected parsers can retain
+    locale-specific support code, but no unselected runtime source declaration may survive.
+    """
+    requested_paths = {(language_dir / name).resolve() for name in requested}
+    for file in sorted(language_dir.rglob("*.kt")):
+        if file.resolve() in requested_paths:
+            continue
+        content = file.read_text(encoding="utf-8")
+        if parser_annotations(content, file.relative_to(language_dir).as_posix()):
+            file.unlink()
+
+    # Remove directories made empty by parser pruning without touching directories that still contain
+    # helper code/resources used by the curated sources.
+    directories = sorted(
+        (path for path in language_dir.rglob("*") if path.is_dir()),
+        key=lambda path: len(path.parts),
+        reverse=True,
+    )
+    for directory in directories:
+        try:
+            directory.rmdir()
+        except OSError:
+            pass
+
+
+def assert_only_requested_parsers_remain(language_dir: Path, requested: list[str]) -> None:
+    requested_paths = {(language_dir / name).resolve() for name in requested}
+    unexpected_files: list[str] = []
+    for file in sorted(language_dir.rglob("*.kt")):
+        annotations = parser_annotations(
+            file.read_text(encoding="utf-8"),
+            file.relative_to(language_dir).as_posix(),
+        )
+        if annotations and file.resolve() not in requested_paths:
+            unexpected_files.append(file.relative_to(language_dir).as_posix())
+    if unexpected_files:
+        fail(
+            "Unselected parser files remain after pruning: "
+            + ", ".join(unexpected_files)
+        )
+
+
 def prepare(manifest: Path, upstream: Path, pack_name: str) -> None:
     root, pack = load_manifest(manifest, pack_name)
     upstream_meta = root["upstream"]
@@ -94,10 +140,8 @@ def prepare(manifest: Path, upstream: Path, pack_name: str) -> None:
         else:
             child.unlink()
 
-    keep = set(requested)
-    for file in language_dir.glob("*.kt"):
-        if file.name not in keep:
-            file.unlink()
+    prune_unselected_parser_files(language_dir, requested)
+    assert_only_requested_parsers_remain(language_dir, requested)
 
     # One Kotlin file can declare several runtime sources. Record the actual annotation names so the
     # finalizer can compare KSP output exactly instead of incorrectly equating file count to source count.


### PR DESCRIPTION
Introduces the first non-destructive foundation for Miyorare-owned sources without replacing the existing Mihon/Tsuki/LNReader runtimes.

- adds provider-neutral canonical source identities
- reserves the `MIYORARE:` namespace for official source packs
- reuses the existing Kotatsu -> Mihon mapping for safe aliases
- keeps Tsuki/UMA/Gekkoushi isolated until equivalence is explicitly verified
- adds unit coverage for identity behavior
- documents download/library invariants and the planned EN/ID rollout

No database schema changes, download moves, file deletion, or automatic provider migration are performed in this slice.

Base: beta @ 56de2e481d7d97cc9b46e4f8801fa823d5db1c61