### PR TITLE
Fix official source-pack shard installation

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/MiyorareOfficialSourcePacks.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/MiyorareOfficialSourcePacks.kt
@@ -12,6 +12,8 @@ data class MiyorareOfficialSourceShard(
  *
  * A logical ID/EN pack may consist of multiple independently built JARs. [assetName] remains the
  * legacy one-JAR asset name so installed clients can keep using immutable pre-shard releases.
+ * The UMA shard deliberately keeps the logical plugin id so upgrading from a legacy one-JAR pack
+ * preserves the user's source visibility choices and stored source identities.
  */
 data class MiyorareOfficialSourcePack(
 	val pluginId: String,
@@ -36,7 +38,7 @@ object MiyorareOfficialSourcePacks {
 			assetName = "miyorare-id.jar",
 			shards = listOf(
 				MiyorareOfficialSourceShard(
-					pluginId = "miyorare-id-uma",
+					pluginId = ID_PLUGIN_ID,
 					displayName = "Miyorare-ID / UMA",
 					assetName = "miyorare-id-uma.jar",
 				),
@@ -54,7 +56,7 @@ object MiyorareOfficialSourcePacks {
 			assetName = "miyorare-en.jar",
 			shards = listOf(
 				MiyorareOfficialSourceShard(
-					pluginId = "miyorare-en-uma",
+					pluginId = EN_PLUGIN_ID,
 					displayName = "Miyorare-EN / UMA",
 					assetName = "miyorare-en-uma.jar",
 				),

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/MiyorareOfficialSourcePacks.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/MiyorareOfficialSourcePacks.kt
@@ -1,17 +1,24 @@
 package org.koitharu.kotatsu.tsuki
 
+/** One independently built runtime shard inside a logical official Miyorare source pack. */
+data class MiyorareOfficialSourceShard(
+	val pluginId: String,
+	val displayName: String,
+	val assetName: String,
+)
+
 /**
  * Trusted metadata for source packs published by Miyorare itself.
  *
- * The list is intentionally small and static. A remote release may only become an official plugin
- * when its plugin id and asset name are declared here, its release tag is in the dedicated source
- * release namespace, and GitHub supplies a matching SHA-256 digest for the downloaded asset.
+ * A logical ID/EN pack may consist of multiple independently built JARs. [assetName] remains the
+ * legacy one-JAR asset name so installed clients can keep using immutable pre-shard releases.
  */
 data class MiyorareOfficialSourcePack(
 	val pluginId: String,
 	val displayName: String,
 	val language: String,
 	val assetName: String,
+	val shards: List<MiyorareOfficialSourceShard>,
 )
 
 object MiyorareOfficialSourcePacks {
@@ -27,17 +34,49 @@ object MiyorareOfficialSourcePacks {
 			displayName = "Miyorare-ID",
 			language = "id",
 			assetName = "miyorare-id.jar",
+			shards = listOf(
+				MiyorareOfficialSourceShard(
+					pluginId = "miyorare-id-uma",
+					displayName = "Miyorare-ID / UMA",
+					assetName = "miyorare-id-uma.jar",
+				),
+				MiyorareOfficialSourceShard(
+					pluginId = "miyorare-id-gekkoushi",
+					displayName = "Miyorare-ID / Gekkoushi",
+					assetName = "miyorare-id-gekkoushi.jar",
+				),
+			),
 		),
 		MiyorareOfficialSourcePack(
 			pluginId = EN_PLUGIN_ID,
 			displayName = "Miyorare-EN",
 			language = "en",
 			assetName = "miyorare-en.jar",
+			shards = listOf(
+				MiyorareOfficialSourceShard(
+					pluginId = "miyorare-en-uma",
+					displayName = "Miyorare-EN / UMA",
+					assetName = "miyorare-en-uma.jar",
+				),
+				MiyorareOfficialSourceShard(
+					pluginId = "miyorare-en-gekkoushi",
+					displayName = "Miyorare-EN / Gekkoushi",
+					assetName = "miyorare-en-gekkoushi.jar",
+				),
+			),
 		),
 	)
 
 	fun find(pluginId: String): MiyorareOfficialSourcePack? =
 		packs.firstOrNull { it.pluginId == pluginId }
+
+	fun findByInstalledPluginId(pluginId: String): MiyorareOfficialSourcePack? =
+		packs.firstOrNull { pack -> pack.pluginId == pluginId || pack.shards.any { it.pluginId == pluginId } }
+
+	fun findShard(pluginId: String): Pair<MiyorareOfficialSourcePack, MiyorareOfficialSourceShard>? =
+		packs.firstNotNullOfOrNull { pack ->
+			pack.shards.firstOrNull { it.pluginId == pluginId }?.let { pack to it }
+		}
 
 	fun versionFromTag(tag: String): SourcePackVersion? {
 		if (!tag.startsWith(RELEASE_TAG_PREFIX)) return null

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/TsukiPluginInstaller.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/TsukiPluginInstaller.kt
@@ -92,8 +92,11 @@ class TsukiPluginInstaller @Inject constructor(
 			isStageAvailable(plugin.provider) && configForPlugin(plugin) != null
 
 	suspend fun checkForUpdate(plugin: TsukiPluginDescriptor): RemoteRelease? = withContext(Dispatchers.IO) {
-		if (plugin.provider == TsukiPluginProvider.MIYORARE || !isStageAvailable(plugin.provider)) {
-			return@withContext null
+		if (!isStageAvailable(plugin.provider)) return@withContext null
+		if (plugin.provider == TsukiPluginProvider.MIYORARE) {
+			val pack = MiyorareOfficialSourcePacks.findByInstalledPluginId(plugin.pluginId) ?: return@withContext null
+			val latest = fetchLatestMiyorarePackRelease(pack)
+			return@withContext latest.releases.first().takeUnless { miyorarePackIsCurrent(pack, latest) }
 		}
 		val config = configForPlugin(plugin) ?: return@withContext null
 		val latest = fetchLatestRelease(config)
@@ -105,17 +108,7 @@ class TsukiPluginInstaller @Inject constructor(
 		val pack = requireNotNull(MiyorareOfficialSourcePacks.find(pluginId)) {
 			"Unknown official Miyorare source pack: $pluginId"
 		}
-		val latest = fetchLatestMiyorarePackRelease(pack)
-		val installed = pluginManager.getPlugins().filter { it.provider == TsukiPluginProvider.MIYORARE }
-		if (latest.legacySingleJar) {
-			val current = installed.firstOrNull { it.pluginId == pack.pluginId }
-			return@withContext current == null || !releaseMatches(current, latest.releases.single())
-		}
-		pack.shards.indices.any { index ->
-			val shard = pack.shards[index]
-			val current = installed.firstOrNull { it.pluginId == shard.pluginId }
-			current == null || !releaseMatches(current, latest.releases[index])
-		}
+		!miyorarePackIsCurrent(pack, fetchLatestMiyorarePackRelease(pack))
 	}
 
 	suspend fun installLatest(provider: TsukiPluginProvider): TsukiPluginDescriptor = withContext(Dispatchers.IO) {
@@ -132,11 +125,12 @@ class TsukiPluginInstaller @Inject constructor(
 	 * bytes are downloaded and validated before the first installed plugin is replaced. If a later
 	 * shard commit fails, every already-replaced shard is rolled back to its previous JAR/state.
 	 */
-	suspend fun installLatestMiyorare(pluginId: String): List<TsukiPluginDescriptor> = withContext(Dispatchers.IO) {
+	suspend fun installLatestMiyorare(pluginId: String): TsukiPluginDescriptor = withContext(Dispatchers.IO) {
 		val pack = requireNotNull(MiyorareOfficialSourcePacks.find(pluginId)) {
 			"Unknown official Miyorare source pack: $pluginId"
 		}
-		installMiyorarePack(pack, fetchLatestMiyorarePackRelease(pack))
+		val installed = installMiyorarePack(pack, fetchLatestMiyorarePackRelease(pack))
+		installed.firstOrNull { it.pluginId == pack.pluginId } ?: installed.first()
 	}
 
 	/** Install the single JAR asset from a public GitHub repository's latest release. */
@@ -277,6 +271,22 @@ class TsukiPluginInstaller @Inject constructor(
 		} finally {
 			staged.forEach(File::delete)
 			snapshots.values.filterNotNull().forEach { it.jar.delete() }
+		}
+	}
+
+	private fun miyorarePackIsCurrent(
+		pack: MiyorareOfficialSourcePack,
+		release: MiyorarePackRelease,
+	): Boolean {
+		val installed = pluginManager.getPlugins().filter { it.provider == TsukiPluginProvider.MIYORARE }
+		if (release.legacySingleJar) {
+			val current = installed.firstOrNull { it.pluginId == pack.pluginId } ?: return false
+			return releaseMatches(current, release.releases.single())
+		}
+		return pack.shards.indices.all { index ->
+			val shard = pack.shards[index]
+			val current = installed.firstOrNull { it.pluginId == shard.pluginId } ?: return@all false
+			releaseMatches(current, release.releases[index])
 		}
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/TsukiPluginInstaller.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/TsukiPluginInstaller.kt
@@ -14,6 +14,8 @@ import org.json.JSONObject
 import org.koitharu.kotatsu.core.network.BaseHttpClient
 import org.koitharu.kotatsu.tsuki.model.TsukiPluginDescriptor
 import org.koitharu.kotatsu.tsuki.model.TsukiPluginProvider
+import org.koitharu.kotatsu.tsuki.model.TsukiPluginState
+import org.koitharu.kotatsu.tsuki.model.TsukiSourceIdentity
 import java.io.File
 import java.io.InputStream
 import java.util.Locale
@@ -45,6 +47,18 @@ class TsukiPluginInstaller @Inject constructor(
 		val sha256: String?,
 	)
 
+	private data class MiyorarePackRelease(
+		val tag: String,
+		val repository: String,
+		val releases: List<RemoteRelease>,
+		val legacySingleJar: Boolean,
+	)
+
+	private data class PreviousPlugin(
+		val descriptor: TsukiPluginDescriptor,
+		val jar: File,
+	)
+
 	fun isStageAvailable(provider: TsukiPluginProvider): Boolean = when (provider) {
 		TsukiPluginProvider.MIYORARE,
 		TsukiPluginProvider.UMA,
@@ -64,22 +78,43 @@ class TsukiPluginInstaller @Inject constructor(
 
 	fun officialMiyorarePacks(): List<MiyorareOfficialSourcePack> = MiyorareOfficialSourcePacks.packs
 
+	/** Representative release for callers that only need version/availability information. */
 	suspend fun latestMiyorareRelease(pluginId: String): RemoteRelease = withContext(Dispatchers.IO) {
-		val config = requireNotNull(miyorarePackConfig(pluginId)) { "Unknown official Miyorare source pack: $pluginId" }
-		requireStageAvailable(config)
-		fetchLatestRelease(config)
+		val pack = requireNotNull(MiyorareOfficialSourcePacks.find(pluginId)) {
+			"Unknown official Miyorare source pack: $pluginId"
+		}
+		fetchLatestMiyorarePackRelease(pack).releases.first()
 	}
 
+	/** Official Miyorare shards are updated only through their logical ID/EN pack button. */
 	fun supportsRemoteUpdate(plugin: TsukiPluginDescriptor): Boolean =
-		isStageAvailable(plugin.provider) && configForPlugin(plugin) != null
+		plugin.provider != TsukiPluginProvider.MIYORARE &&
+			isStageAvailable(plugin.provider) && configForPlugin(plugin) != null
 
 	suspend fun checkForUpdate(plugin: TsukiPluginDescriptor): RemoteRelease? = withContext(Dispatchers.IO) {
-		if (!isStageAvailable(plugin.provider)) return@withContext null
+		if (plugin.provider == TsukiPluginProvider.MIYORARE || !isStageAvailable(plugin.provider)) {
+			return@withContext null
+		}
 		val config = configForPlugin(plugin) ?: return@withContext null
 		val latest = fetchLatestRelease(config)
-		latest.takeUnless { release ->
-			release.tag == plugin.version &&
-				(release.sha256 == null || release.sha256.equals(plugin.sha256, ignoreCase = true))
+		latest.takeUnless { release -> releaseMatches(plugin, release) }
+	}
+
+	/** True when the logical official pack is missing or any required shard differs from latest. */
+	suspend fun hasMiyorarePackUpdate(pluginId: String): Boolean = withContext(Dispatchers.IO) {
+		val pack = requireNotNull(MiyorareOfficialSourcePacks.find(pluginId)) {
+			"Unknown official Miyorare source pack: $pluginId"
+		}
+		val latest = fetchLatestMiyorarePackRelease(pack)
+		val installed = pluginManager.getPlugins().filter { it.provider == TsukiPluginProvider.MIYORARE }
+		if (latest.legacySingleJar) {
+			val current = installed.firstOrNull { it.pluginId == pack.pluginId }
+			return@withContext current == null || !releaseMatches(current, latest.releases.single())
+		}
+		pack.shards.indices.any { index ->
+			val shard = pack.shards[index]
+			val current = installed.firstOrNull { it.pluginId == shard.pluginId }
+			current == null || !releaseMatches(current, latest.releases[index])
 		}
 	}
 
@@ -91,9 +126,17 @@ class TsukiPluginInstaller @Inject constructor(
 		installFromConfig(config)
 	}
 
-	suspend fun installLatestMiyorare(pluginId: String): TsukiPluginDescriptor = withContext(Dispatchers.IO) {
-		val config = requireNotNull(miyorarePackConfig(pluginId)) { "Unknown official Miyorare source pack: $pluginId" }
-		installFromConfig(config)
+	/**
+	 * Installs one logical Miyorare pack. New releases consist of independent UMA + Gekkoushi JARs;
+	 * legacy one-JAR releases remain installable until a shard release is published. All new shard
+	 * bytes are downloaded and validated before the first installed plugin is replaced. If a later
+	 * shard commit fails, every already-replaced shard is rolled back to its previous JAR/state.
+	 */
+	suspend fun installLatestMiyorare(pluginId: String): List<TsukiPluginDescriptor> = withContext(Dispatchers.IO) {
+		val pack = requireNotNull(MiyorareOfficialSourcePacks.find(pluginId)) {
+			"Unknown official Miyorare source pack: $pluginId"
+		}
+		installMiyorarePack(pack, fetchLatestMiyorarePackRelease(pack))
 	}
 
 	/** Install the single JAR asset from a public GitHub repository's latest release. */
@@ -103,6 +146,14 @@ class TsukiPluginInstaller @Inject constructor(
 
 	/** Manual update/reinstall using the exact remote origin already persisted for this plugin. */
 	suspend fun installLatest(plugin: TsukiPluginDescriptor): TsukiPluginDescriptor = withContext(Dispatchers.IO) {
+		if (plugin.provider == TsukiPluginProvider.MIYORARE) {
+			val pack = requireNotNull(MiyorareOfficialSourcePacks.findByInstalledPluginId(plugin.pluginId)) {
+				"Unknown official Miyorare source pack: ${plugin.pluginId}"
+			}
+			return@withContext installMiyorarePack(pack, fetchLatestMiyorarePackRelease(pack))
+				.firstOrNull { it.pluginId == plugin.pluginId }
+				?: error("Updated Miyorare pack did not contain ${plugin.pluginId}")
+		}
 		val config = requireNotNull(configForPlugin(plugin)) { "Plugin has no supported remote repository" }
 		installFromConfig(config)
 	}
@@ -136,20 +187,117 @@ class TsukiPluginInstaller @Inject constructor(
 		val temp = File.createTempFile("tsuki-${config.pluginId}-", ".jar", context.cacheDir)
 		try {
 			downloadRelease(release, temp)
-			return pluginManager.installLocalJar(
-				sourceFile = temp,
-				request = TsukiPluginManager.InstallRequest(
-					pluginId = config.pluginId,
-					displayName = config.displayName,
-					provider = config.provider,
-					origin = config.repositoryUrl,
-					version = release.tag,
-				),
-			)
+			return installDownloadedRelease(config, release, temp)
 		} finally {
 			temp.delete()
 		}
 	}
+
+	@WorkerThread
+	private fun installMiyorarePack(
+		pack: MiyorareOfficialSourcePack,
+		release: MiyorarePackRelease,
+	): List<TsukiPluginDescriptor> {
+		if (release.legacySingleJar) {
+			val config = miyorareLegacyConfig(pack, release.repository)
+			val remote = release.releases.single()
+			val temp = File.createTempFile("tsuki-${pack.pluginId}-legacy-", ".jar", context.cacheDir)
+			try {
+				downloadRelease(remote, temp)
+				return listOf(installDownloadedRelease(config, remote, temp))
+			} finally {
+				temp.delete()
+			}
+		}
+
+		require(release.releases.size == pack.shards.size) { "Official Miyorare shard release is incomplete" }
+		val configs = pack.shards.map { shard -> miyorareShardConfig(pack, shard, release.repository) }
+		val staged = configs.map { config ->
+			File.createTempFile("tsuki-${config.pluginId}-stage-", ".jar", context.cacheDir)
+		}
+		val snapshots = LinkedHashMap<String, PreviousPlugin?>()
+		val installedNow = ArrayList<String>(configs.size)
+		try {
+			// Fail before touching installed state if either network asset, checksum, or plugin container is bad.
+			for (index in staged.indices) {
+				downloadRelease(release.releases[index], staged[index])
+			}
+
+			for (config in configs) {
+				val previous = pluginManager.findPlugin(TsukiPluginProvider.MIYORARE, config.pluginId)
+				val previousJar = previous?.let(pluginManager::pluginJar)
+				snapshots[config.pluginId] = if (previous != null && previousJar != null && previousJar.isFile) {
+					val copy = File.createTempFile("tsuki-${config.pluginId}-rollback-", ".jar", context.cacheDir)
+					previousJar.copyTo(copy, overwrite = true)
+					PreviousPlugin(previous, copy)
+				} else {
+					null
+				}
+			}
+
+			val result = ArrayList<TsukiPluginDescriptor>(configs.size)
+			for (index in configs.indices) {
+				val installed = installDownloadedRelease(configs[index], release.releases[index], staged[index])
+				installedNow += configs[index].pluginId
+				result += installed
+			}
+			return result
+		} catch (error: Throwable) {
+			for (pluginId in installedNow.asReversed()) {
+				val snapshot = snapshots[pluginId]
+				if (snapshot == null) {
+					runCatching { pluginManager.remove(TsukiPluginProvider.MIYORARE, pluginId) }
+					continue
+				}
+				runCatching {
+					val old = snapshot.descriptor
+					pluginManager.installLocalJar(
+						sourceFile = snapshot.jar,
+						request = TsukiPluginManager.InstallRequest(
+							pluginId = old.pluginId,
+							displayName = old.displayName,
+							provider = old.provider,
+							origin = old.origin,
+							version = old.version,
+						),
+					)
+					val states = old.sources.associate { source ->
+						TsukiSourceIdentity(old.provider, old.pluginId, source.name) to
+							(source.name in old.enabledSourceNames)
+					}
+					pluginManager.setSourceStates(states)
+					pluginManager.setEnabled(
+						old.provider,
+						old.pluginId,
+						old.state == TsukiPluginState.ENABLED,
+					)
+				}
+			}
+			throw error
+		} finally {
+			staged.forEach(File::delete)
+			snapshots.values.filterNotNull().forEach { it.jar.delete() }
+		}
+	}
+
+	private fun installDownloadedRelease(
+		config: ProviderConfig,
+		release: RemoteRelease,
+		file: File,
+	): TsukiPluginDescriptor = pluginManager.installLocalJar(
+		sourceFile = file,
+		request = TsukiPluginManager.InstallRequest(
+			pluginId = config.pluginId,
+			displayName = config.displayName,
+			provider = config.provider,
+			origin = config.repositoryUrl,
+			version = release.tag,
+		),
+	)
+
+	private fun releaseMatches(plugin: TsukiPluginDescriptor, release: RemoteRelease): Boolean =
+		release.tag == plugin.version &&
+			(release.sha256 == null || release.sha256.equals(plugin.sha256, ignoreCase = true))
 
 	private fun requireStageAvailable(config: ProviderConfig) {
 		require(isStageAvailable(config.provider)) {
@@ -179,9 +327,46 @@ class TsukiPluginInstaller @Inject constructor(
 	}
 
 	@WorkerThread
+	private fun fetchLatestMiyorarePackRelease(pack: MiyorareOfficialSourcePack): MiyorarePackRelease {
+		val repositories = listOf(
+			MiyorareOfficialSourcePacks.REPOSITORY,
+			MiyorareOfficialSourcePacks.LEGACY_REPOSITORY,
+		).distinct()
+		var lastFailure: Exception? = null
+		for (repository in repositories) {
+			try {
+				val root = fetchLatestPrefixedReleaseRoot(repository)
+				val tag = root.getString("tag_name")
+				val names = releaseAssetNames(root)
+				if (pack.shards.all { it.assetName in names }) {
+					val releases = pack.shards.map { shard ->
+						parseRelease(miyorareShardConfig(pack, shard, repository), root)
+					}
+					return MiyorarePackRelease(tag, repository, releases, legacySingleJar = false)
+				}
+				if (pack.assetName in names) {
+					val remote = parseRelease(miyorareLegacyConfig(pack, repository), root)
+					return MiyorarePackRelease(tag, repository, listOf(remote), legacySingleJar = true)
+				}
+				error("Release $tag has neither the complete ${pack.displayName} shard set nor ${pack.assetName}")
+			} catch (error: Exception) {
+				lastFailure = error
+			}
+		}
+		throw lastFailure ?: IllegalStateException("No official Miyorare source-pack release is configured")
+	}
+
+	private fun releaseAssetNames(root: JSONObject): Set<String> {
+		val assets = root.getJSONArray("assets")
+		return buildSet(assets.length()) {
+			for (index in 0 until assets.length()) add(assets.getJSONObject(index).optString("name"))
+		}
+	}
+
+	@WorkerThread
 	private fun fetchLatestReleaseFromRepository(config: ProviderConfig): RemoteRelease {
 		if (config.releaseTagPrefix != null) {
-			return fetchLatestPrefixedRelease(config)
+			return parseRelease(config, fetchLatestPrefixedReleaseRoot(config.repository))
 		}
 		val request = Request.Builder()
 			.url("https://api.github.com/repos/${config.repository}/releases/latest")
@@ -195,10 +380,9 @@ class TsukiPluginInstaller @Inject constructor(
 	}
 
 	@WorkerThread
-	private fun fetchLatestPrefixedRelease(config: ProviderConfig): RemoteRelease {
-		val prefix = requireNotNull(config.releaseTagPrefix)
+	private fun fetchLatestPrefixedReleaseRoot(repository: String): JSONObject {
 		val request = Request.Builder()
-			.url("https://api.github.com/repos/${config.repository}/releases?per_page=30")
+			.url("https://api.github.com/repos/$repository/releases?per_page=30")
 			.header("Accept", "application/vnd.github+json")
 			.header("X-GitHub-Api-Version", "2022-11-28")
 			.build()
@@ -210,13 +394,11 @@ class TsukiPluginInstaller @Inject constructor(
 				val release = releases.getJSONObject(i)
 				if (release.optBoolean("draft") || release.optBoolean("prerelease")) continue
 				val tag = release.optString("tag_name")
-				if (!tag.startsWith(prefix)) continue
 				val version = MiyorareOfficialSourcePacks.versionFromTag(tag) ?: continue
 				candidates += version to release
 			}
-			val selected = candidates.maxByOrNull { it.first }?.second
+			return candidates.maxByOrNull { it.first }?.second
 				?: error("No stable official Miyorare source-pack release is published yet")
-			return parseRelease(config, selected)
 		}
 	}
 
@@ -345,9 +527,7 @@ class TsukiPluginInstaller @Inject constructor(
 	}
 
 	private fun configForPlugin(plugin: TsukiPluginDescriptor): ProviderConfig? {
-		if (plugin.provider == TsukiPluginProvider.MIYORARE) {
-			return miyorarePackConfig(plugin.pluginId)
-		}
+		if (plugin.provider == TsukiPluginProvider.MIYORARE) return null
 		knownProvider(plugin.provider)?.let { return it }
 		if (plugin.provider != TsukiPluginProvider.CUSTOM || !plugin.origin.startsWith("https://github.com/")) {
 			return null
@@ -386,19 +566,30 @@ class TsukiPluginInstaller @Inject constructor(
 		.take(64)
 		.ifBlank { "custom" }
 
-	private fun miyorarePackConfig(pluginId: String): ProviderConfig? {
-		val pack = MiyorareOfficialSourcePacks.find(pluginId) ?: return null
-		return ProviderConfig(
+	private fun miyorareLegacyConfig(pack: MiyorareOfficialSourcePack, repository: String): ProviderConfig =
+		ProviderConfig(
 			provider = TsukiPluginProvider.MIYORARE,
 			pluginId = pack.pluginId,
 			displayName = pack.displayName,
-			repository = MiyorareOfficialSourcePacks.REPOSITORY,
+			repository = repository,
 			assetName = pack.assetName,
 			releaseTagPrefix = MiyorareOfficialSourcePacks.RELEASE_TAG_PREFIX,
 			requireSha256 = true,
-			fallbackRepositories = listOf(MiyorareOfficialSourcePacks.LEGACY_REPOSITORY),
 		)
-	}
+
+	private fun miyorareShardConfig(
+		pack: MiyorareOfficialSourcePack,
+		shard: MiyorareOfficialSourceShard,
+		repository: String,
+	): ProviderConfig = ProviderConfig(
+		provider = TsukiPluginProvider.MIYORARE,
+		pluginId = shard.pluginId,
+		displayName = shard.displayName,
+		repository = repository,
+		assetName = shard.assetName,
+		releaseTagPrefix = MiyorareOfficialSourcePacks.RELEASE_TAG_PREFIX,
+		requireSha256 = true,
+	)
 
 	private fun knownProvider(provider: TsukiPluginProvider): ProviderConfig? = when (provider) {
 		TsukiPluginProvider.MIYORARE -> null

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/TsukiPluginProbe.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tsuki/TsukiPluginProbe.kt
@@ -94,17 +94,18 @@ internal object TsukiPluginProbe {
 	}
 
 	/**
-	 * Official combined Miyorare packs can retain extra Gekkoushi enum entries solely to satisfy the
-	 * upstream compile-time dependency graph. The embedded provenance sourceNames list is the only
-	 * set exposed to users. Ordinary UMA/Gekkoushi/custom plugins have no metadata entry and retain
-	 * the existing behavior of exposing every enum constant.
+	 * Official Miyorare packs embed an exposed source allowlist. Schema 1 is the legacy one-JAR
+	 * release format; schema 2 is the independent UMA/Gekkoushi shard format. Both carry sourceNames
+	 * and are safe to probe. Ordinary third-party plugins have no metadata entry and retain the
+	 * existing behavior of exposing every enum constant.
 	 */
 	private fun readMiyorareSourceAllowlist(file: File): Set<String>? = ZipFile(file).use { archive ->
 		val entry = archive.getEntry(MIYORARE_PACK_METADATA) ?: return@use null
 		val root = archive.getInputStream(entry).bufferedReader().use { reader ->
 			JSONObject(reader.readText())
 		}
-		require(root.optInt("schema", 0) >= 2) { "Unsupported Miyorare source-pack metadata schema" }
+		val schema = root.optInt("schema", 0)
+		require(schema == 1 || schema == 2) { "Unsupported Miyorare source-pack metadata schema" }
 		val array = root.optJSONArray("sourceNames")
 			?: error("Miyorare source-pack metadata has no sourceNames")
 		val names = LinkedHashSet<String>(array.length())

--- a/app/src/test/kotlin/org/koitharu/kotatsu/tsuki/MiyorareOfficialSourcePacksTest.kt
+++ b/app/src/test/kotlin/org/koitharu/kotatsu/tsuki/MiyorareOfficialSourcePacksTest.kt
@@ -8,13 +8,31 @@ import org.junit.Test
 class MiyorareOfficialSourcePacksTest {
 
 	@Test
-	fun `official packs are unique and use jar assets`() {
+	fun `official packs are unique and define two physical shards`() {
 		val packs = MiyorareOfficialSourcePacks.packs
 		assertEquals(2, packs.size)
 		assertEquals(packs.size, packs.map { it.pluginId }.toSet().size)
-		assertEquals(packs.size, packs.map { it.assetName }.toSet().size)
-		assertTrue(packs.all { it.assetName.endsWith(".jar") })
 		assertEquals(setOf("id", "en"), packs.map { it.language }.toSet())
+		assertTrue(packs.all { it.assetName.endsWith(".jar") })
+		assertTrue(packs.all { it.shards.size == 2 })
+		assertTrue(packs.flatMap { it.shards }.all { it.assetName.endsWith(".jar") })
+		assertEquals(
+			packs.sumOf { it.shards.size },
+			packs.flatMap { it.shards }.map { it.assetName }.toSet().size,
+		)
+	}
+
+	@Test
+	fun `uma shard preserves logical plugin identity for legacy upgrade`() {
+		for (pack in MiyorareOfficialSourcePacks.packs) {
+			val uma = pack.shards.first()
+			val gekkoushi = pack.shards.last()
+			assertEquals(pack.pluginId, uma.pluginId)
+			assertTrue(uma.assetName.endsWith("-uma.jar"))
+			assertTrue(gekkoushi.pluginId.endsWith("-gekkoushi"))
+			assertTrue(gekkoushi.assetName.endsWith("-gekkoushi.jar"))
+			assertEquals(pack, MiyorareOfficialSourcePacks.findByInstalledPluginId(gekkoushi.pluginId))
+		}
 	}
 
 	@Test

--- a/extensions/miyorare-sources/tools/prepare_pack.py
+++ b/extensions/miyorare-sources/tools/prepare_pack.py
@@ -166,7 +166,10 @@ def prepare(manifest: Path, upstream: Path, pack_name: str) -> None:
         duplicates = sorted({name for name in source_names if source_names.count(name) > 1})
         fail(f"Pack {pack_name} contains duplicate runtime source names: {', '.join(duplicates)}")
 
-    plugin_id = f"{pack['pluginId']}-uma"
+    # The UMA shard keeps the logical plugin id. This lets a shard release replace an older
+    # one-JAR Miyorare-ID/EN install in place while preserving enabled-source choices and stored
+    # Tsuki source identities. Only the Gekkoushi shard needs a separate physical plugin id.
+    plugin_id = pack["pluginId"]
     asset_name = f"miyorare-{pack_name}-uma.jar"
     metadata = {
         "schema": 2,


### PR DESCRIPTION
Fix the runtime failure shown when installing official Miyorare-ID/EN source packs after PR #27.

Changes:
- accept both legacy schema 1 and shard schema 2 embedded source-pack metadata
- model Miyorare-ID/EN as logical packs with independent UMA + Gekkoushi shard assets
- keep the UMA shard on the existing logical plugin id (`miyorare-id` / `miyorare-en`) so legacy installs upgrade in-place and preserve stored source identity / enabled-source state
- download and validate every shard before replacing installed state
- rollback already-replaced shards if a later shard install fails
- keep old single-JAR releases installable until a shard release is published
- check both shards when the existing Install/update Miyorare-ID/EN button decides whether the logical pack is current
- preserve UMA authority; Gekkoushi remains the non-duplicate supplemental shard

Base: beta. Does not touch main.